### PR TITLE
Consistent Makefile between Medik8s Operators - Updating Targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ export DOCKER_GO=docker run --rm -v $$(pwd):/home/go/src/github.com/medik8s/node
 	-e "GOPATH=/go" -e "GOFLAGS=-mod=vendor" -e "XDG_CACHE_HOME=/tmp/.cache" \
 	-e "VERSION=$(VERSION)" -e "IMAGE_REGISTRY=$(IMAGE_REGISTRY)" \
 	--entrypoint /bin/bash golang:$(GO_VERSION) -c
-
+.PHONY: all
 all: build
 
 ##@ General
@@ -108,85 +108,106 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
+.PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
-
+.PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+.PHONY:generate
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: fmt
 fmt: goimports ## Run go goimports against code.
 	$(GOIMPORTS) -w ./api ./controllers ./test
 
+.PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./api/... ./controllers/... ./test/...
 
+.PHONY: go-vendor
 go-vendor:
 	go mod vendor
 
+.PHONY: go-tidy
 go-tidy:
 	go mod tidy
 
+.PHONY: test
 test: manifests generate fmt vet go-tidy go-vendor verify-unchanged envtest ginkgo ## Run tests.
 	ACK_GINKGO_DEPRECATIONS=1.16.4 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin)" $(GINKGO) -v -r --keepGoing -requireSuite ./api/... ./controllers/... -coverprofile cover.out
 
 ##@ Build
 
+.PHONY: build
 build: ## Build manager binary.
 	./hack/build.sh
 
+.PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+.PHONY: docker-build
 docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
+.PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
+.PHONY: must-gather-build
 must-gather-build: ## Build must-gather image.
 	docker build -t ${MUST_GATHER_IMAGE} ./must-gather
 
+.PHONY: must-gather-push
 must-gather-push: ## Push must-gather image.
 	docker push ${MUST_GATHER_IMAGE}
 
 ##@ Deployment
 
+.PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
+.PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
+.PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+.PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
-
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+.PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
+.PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
+.PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 GOIMPORTS = $(shell pwd)/bin/goimports
+.PHONY: goimports
 goimports: ## Download goimports locally if necessary.
 	$(call go-get-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports@v0.1.6)
 
 GINKGO = $(shell pwd)/bin/ginkgo
+.PHONY: ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
 	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/ginkgo@v1.16.4)
 
@@ -264,7 +285,7 @@ endif
 catalog-build: opm ## Build a catalog image.
 	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
-# Push the catalog image.
+
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
@@ -272,22 +293,22 @@ catalog-push: ## Push a catalog image.
 
 ##@ Targets used by CI
 
-.PHONY: check ## Dockerized version of make test
-check:
+.PHONY: check 
+check: ## Dockerized version of make test
 	$(DOCKER_GO) "make test"
 
 .PHONY: verify-unchanged
 verify-unchanged:
 	./hack/verify-unchanged.sh
 
-.PHONY: container-build ## Build containers
-container-build: check
+.PHONY: container-build 
+container-build: check ## Build containers
 	$(DOCKER_GO) "make bundle"
 	make docker-build bundle-build
 
-.PHONY: container-push ## Push containers (NOTE: catalog can't be build before bundle was pushed)
-container-push: docker-push bundle-push catalog-build catalog-push
+.PHONY: container-push 
+container-push: docker-push bundle-push catalog-build catalog-push ## Push containers (NOTE: catalog can't be build before bundle was pushed)
 
-.PHONY: cluster-functest ## Run e2e tests in a real cluster
-cluster-functest: ginkgo
+.PHONY: cluster-functest 
+cluster-functest: ginkgo ## Run e2e tests in a real cluster
 	./hack/functest.sh


### PR DESCRIPTION
For better collaboration I am aligning our Makefiles, and this is the **first** PR.
It would be easier (or not) to see changes, commit after commit.

1. Add PHONY to each target and update it's description (use `make help`)
2. Use `kubectl` or `oc` and 'test-no-verify` target (for passing CI test when there are uncommitted changes).