### PR TITLE
update PodDisruptionBudget API

### DIFF
--- a/api/v1beta1/nodemaintenance_webhook.go
+++ b/api/v1beta1/nodemaintenance_webhook.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -197,7 +197,7 @@ func (v *NodeMaintenanceValidator) validateMasterQuorum(nodeName string) error {
 	}
 
 	// check the etcd-quorum-guard PodDisruptionBudget if we can drain a master node
-	var pdb v1beta1.PodDisruptionBudget
+	var pdb policyv1.PodDisruptionBudget
 	key := types.NamespacedName{
 		Namespace: EtcdQuorumPDBNamespace,
 		Name:      EtcdQuorumPDBName,

--- a/api/v1beta1/nodemaintenance_webhook_test.go
+++ b/api/v1beta1/nodemaintenance_webhook_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -97,7 +97,7 @@ var _ = Describe("NodeMaintenance Validation", func() {
 
 			Context("with potential quorum violation", func() {
 
-				var pdb *v1beta1.PodDisruptionBudget
+				var pdb *policyv1.PodDisruptionBudget
 
 				BeforeEach(func() {
 					pdb = getTestPDB()
@@ -121,7 +121,7 @@ var _ = Describe("NodeMaintenance Validation", func() {
 
 			Context("without potential quorum violation", func() {
 
-				var pdb *v1beta1.PodDisruptionBudget
+				var pdb *policyv1.PodDisruptionBudget
 
 				BeforeEach(func() {
 					pdb = getTestPDB()
@@ -202,8 +202,8 @@ func getTestNode(name string, isMaster bool) *v1.Node {
 	return node
 }
 
-func getTestPDB() *v1beta1.PodDisruptionBudget {
-	return &v1beta1.PodDisruptionBudget{
+func getTestPDB() *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: EtcdQuorumPDBNamespace,
 			Name:      EtcdQuorumPDBName,

--- a/api/v1beta1/webhook_suite_test.go
+++ b/api/v1beta1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = policyv1beta1.AddToScheme(scheme)
+	err = policyv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = corev1.AddToScheme(scheme)


### PR DESCRIPTION
Updating PodDisruptionBudget API  because of `policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1` (for more see [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125)).

Signed-off-by: oraz <oraz@redhat.com>