### PR TITLE
Fix Scorecard tests

### DIFF
--- a/api/v1beta1/nodemaintenance_types.go
+++ b/api/v1beta1/nodemaintenance_types.go
@@ -46,8 +46,10 @@ type NodeMaintenanceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Node name to apply maintanance on/off
+	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	NodeName string `json:"nodeName"`
 	// Reason for maintanance
+	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	Reason string `json:"reason,omitempty"`
 }
 
@@ -57,16 +59,22 @@ type NodeMaintenanceStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Phase MaintenancePhase `json:"phase,omitempty"`
 	// LastError represents the latest error if any in the latest reconciliation
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	LastError string `json:"lastError,omitempty"`
 	// PendingPods is a list of pending pods for eviction
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	PendingPods []string `json:"pendingPods,omitempty"`
 	// TotalPods is the total number of all pods on the node from the start
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	TotalPods int `json:"totalpods,omitempty"`
 	// EvictionPods is the total number of pods up for eviction from the start
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	EvictionPods int `json:"evictionPods,omitempty"`
 	// Consecutive number of errors upon obtaining a lease
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	ErrorOnLeaseCount int `json:"errorOnLeaseCount,omitempty"`
 }
 
@@ -75,6 +83,7 @@ type NodeMaintenanceStatus struct {
 //+kubebuilder:resource:scope=Cluster,shortName=nm
 
 // NodeMaintenance is the Schema for the nodemaintenances API
+// +operator-sdk:csv:customresourcedefinitions:resources={{"NodeMaintenance","v1beta1","nodemaintenances"}}
 type NodeMaintenance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -33,6 +33,38 @@ spec:
       displayName: Node Maintenance
       kind: NodeMaintenance
       name: nodemaintenances.nodemaintenance.medik8s.io
+      resources:
+      - kind: NodeMaintenance
+        name: nodemaintenances
+        version: v1beta1
+      specDescriptors:
+      - description: Node name to apply maintanance on/off
+        displayName: Node Name
+        path: nodeName
+      - description: Reason for maintanance
+        displayName: Reason
+        path: reason
+      statusDescriptors:
+      - description: Consecutive number of errors upon obtaining a lease
+        displayName: Error On Lease Count
+        path: errorOnLeaseCount
+      - description: EvictionPods is the total number of pods up for eviction from
+          the start
+        displayName: Eviction Pods
+        path: evictionPods
+      - description: LastError represents the latest error if any in the latest reconciliation
+        displayName: Last Error
+        path: lastError
+      - description: PendingPods is a list of pending pods for eviction
+        displayName: Pending Pods
+        path: pendingPods
+      - description: Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
+        displayName: Phase
+        path: phase
+      - description: TotalPods is the total number of all pods on the node from the
+          start
+        displayName: Total Pods
+        path: totalpods
       version: v1beta1
   description: |
     Node Maintenance Operator (NMO)

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -18,6 +18,38 @@ spec:
       displayName: Node Maintenance
       kind: NodeMaintenance
       name: nodemaintenances.nodemaintenance.medik8s.io
+      resources:
+      - kind: NodeMaintenance
+        name: nodemaintenances
+        version: v1beta1
+      specDescriptors:
+      - description: Node name to apply maintanance on/off
+        displayName: Node Name
+        path: nodeName
+      - description: Reason for maintanance
+        displayName: Reason
+        path: reason
+      statusDescriptors:
+      - description: Consecutive number of errors upon obtaining a lease
+        displayName: Error On Lease Count
+        path: errorOnLeaseCount
+      - description: EvictionPods is the total number of pods up for eviction from
+          the start
+        displayName: Eviction Pods
+        path: evictionPods
+      - description: LastError represents the latest error if any in the latest reconciliation
+        displayName: Last Error
+        path: lastError
+      - description: PendingPods is a list of pending pods for eviction
+        displayName: Pending Pods
+        path: pendingPods
+      - description: Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
+        displayName: Phase
+        path: phase
+      - description: TotalPods is the total number of all pods on the node from the
+          start
+        displayName: Total Pods
+        path: totalpods
       version: v1beta1
   description: |
     Node Maintenance Operator (NMO)


### PR DESCRIPTION
Some Scorecard tests have failed similarly to [PP #142 PR](https://github.com/medik8s/poison-pill/pull/142):
- olm-crds-have-resources-test
- olm-spec-descriptors
- olm-status-descriptors-test

Using API code markers for CSV in the CR_types.go file resolves that (see also [here](https://sdk.operatorframework.io/docs/building-operators/golang/references/markers/)).
Signed-off-by: oraz <oraz@redhat.com>