### PR TITLE
Fix e2e test - etcd-quorum-guard new name

### DIFF
--- a/api/v1beta1/nodemaintenance_webhook.go
+++ b/api/v1beta1/nodemaintenance_webhook.go
@@ -41,7 +41,7 @@ const (
 )
 
 const (
-	EtcdQuorumPDBName      = "etcd-quorum-guard"
+	EtcdQuorumPDBName      = "etcd-guard-pdb"
 	EtcdQuorumPDBNamespace = "openshift-etcd"
 	LabelNameRoleMaster    = "node-role.kubernetes.io/master"
 )


### PR DESCRIPTION
We use webhook for checking the etcd-quorum-guard and ensuring that we don't put master nodes into maintenance mode which could interfere with the quorum of etcd between working masters.
Lately, after updating to OCP 4.11 in our CI,  we have got errors in our e2e tests regarding that and apparently it is because the code have been checking  the etcd-quorum-guard with the old name (`etcd-quorum-guarde`) and not with the new one `etcd-guard-pdb`.