### PR TITLE
Consistent Makefile between Medik8s Operators - Installation tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,4 +363,4 @@ container-push:  ## Push containers (NOTE: catalog can't be build before bundle 
 
 .PHONY: cluster-functest 
 cluster-functest: ginkgo ## Run e2e tests in a real cluster
-	./hack/functest.sh
+	./hack/functest.sh $(GINKGO_VERSION)

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -17,11 +17,19 @@ if [ -n "${OPENSHIFT_CI}" ]; then
     NO_COLOR="-noColor"
 fi
 
+if [ $# -ne 1 ]
+  then
+    echo "Expecing one variable - ginkgo version"
+    exit 1
+else
+    echo "Running E2e test with ginkgo version $1"
+fi
+
 # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
 # -r: run suites recursively
 # --keepGoing: don't stop on failing suite
 # -requireSuite: fail if tests are not executed because of missing suite
-ACK_GINKGO_DEPRECATIONS=1.16.4 ./bin/ginkgo $NO_COLOR -v -r --keepGoing -requireSuite ./test/e2e
+ACK_GINKGO_DEPRECATIONS=$1 ./bin/ginkgo/$1/ginkgo $NO_COLOR -v -r --keepGoing -requireSuite ./test/e2e
 
 if [[ $? != 0 ]]; then
     echo "E2e tests FAILED"


### PR DESCRIPTION
For better collaboration I am aligning our Makefiles, and this is the **second** PR.

Adding two functions for installing tools -`go-install-tool` and `operator-framework-tool` because of the [deprecation of 'go get' for installing executables](https://go.dev/doc/go-get-install-deprecation).
They both remove the old directory, and then install (with `go install` rather than `go-get`)/download the tool into a new directory under the bin directory.
In addition to that we are passing the Ginkgo version for e2e tests.