### PR TITLE
Use ubi-micro as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ COPY .git/ .git/
 # Build
 RUN ./hack/build.sh
 
-# Use ubi8 as minimal base image to package the manager binary
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# Use ubi-micro as minimal base image to package the manager binary - https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 USER 65532:65532


### PR DESCRIPTION
Updating the current base image, _[ubi-minimal](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#con_understanding-the-ubi-minimal-images_assembly_types-of-container-images)_, to  a newer and even smaller image , _[ubi-micro](https://www.redhat.com/en/blog/introduction-ubi-micro)_,  for building the operator (in Dockerfile).