### PR TITLE
CI Fix: adding new target (container-build-and-push)

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Build and push CSV 0.0.1 + latest images for PR merges to main
         if: ${{ github.ref_type != 'tag' }}
-        run: export IMAGE_REGISTRY=quay.io/medik8s && make container-build container-push must-gather-build must-gather-push
+        run: export IMAGE_REGISTRY=quay.io/medik8s && make container-build-and-push
 
       - name: Build and push versioned CSV and images for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export IMAGE_REGISTRY=quay.io/medik8s && export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build container-push must-gather-build must-gather-push
+        run: export IMAGE_REGISTRY=quay.io/medik8s && export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push

--- a/Makefile
+++ b/Makefile
@@ -337,10 +337,6 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-.PHONY: build-push-iib
-build-push-iib: ## Build and push all the three images to quay (docker, bundle, and catalog).
-	docker-build bundle bundle-build container-push 
-
 ##@ Targets used by CI
 
 .PHONY: check 
@@ -354,11 +350,13 @@ verify-unchanged: ## Verify there are no un-committed changes
 .PHONY: container-build 
 container-build: check ## Build containers
 	$(DOCKER_GO) "make bundle"
-	make docker-build bundle-build
+	make docker-build bundle-build must-gather-build
 
 .PHONY: container-push 
-container-push:  ## Push containers (NOTE: catalog can't be build before bundle was pushed)
-	docker-push bundle-push catalog-build catalog-push
+container-push: docker-push bundle-push catalog-build catalog-push must-gather-push ## Push containers (NOTE: catalog can't be build before bundle was pushed)
+
+.PHONY: container-build-and-push
+container-build-and-push: container-build container-push ## Build and push all the four images to quay (docker, bundle, catalog, and must-gather).
 
 .PHONY: cluster-functest 
 cluster-functest: ginkgo ## Run e2e tests in a real cluster


### PR DESCRIPTION
A Github job, _Publish Container Images_, which runs after each merged PR has failed, in the last three merged PRs, due to not depending on the target `container-push`.
In addition, I have added the new target `container-build-and-push` to _Publish Container Images_ job which will build and push all the four containers (docker, bundle, catalog, and must-gather) to quay.