### PR TITLE
Add drain duration information

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,13 @@ status:
 
 `evictionPods` is the total number of pods up for eviction from the start.
 
+`drainProgress` shows the percentage completion of draining the node.
+
 `lastError` represents the latest error if any for the latest reconciliation.
 
-`pendingPods` PendingPods is a list of pending pods for eviction.
+`lastUpdate` is the last time the status has been updated.
+
+`pendingPods` is a list of pending pods for eviction.
 
 `phase` is the representation of the maintenance progress and can hold a string value of: Running|Succeeded.
 The phase is updated for each processing attempt on the CR.

--- a/api/v1beta1/nodemaintenance_types.go
+++ b/api/v1beta1/nodemaintenance_types.go
@@ -61,6 +61,12 @@ type NodeMaintenanceStatus struct {
 	// Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Phase MaintenancePhase `json:"phase,omitempty"`
+	// Percentage completion of draining the node
+	//+operator-sdk:csv:customresourcedefinitions:type=status
+	DrainProgress int `json:"drainProgress,omitempty"`
+	// The last time the status has been updated
+	//+operator-sdk:csv:customresourcedefinitions:type=status
+	LastUpdate metav1.Time `json:"lastUpdate,omitempty"`
 	// LastError represents the latest error if any in the latest reconciliation
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	LastError string `json:"lastError,omitempty"`

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -47,6 +47,9 @@ spec:
         displayName: Reason
         path: reason
       statusDescriptors:
+      - description: Percentage completion of draining the node
+        displayName: Drain Progress
+        path: drainProgress
       - description: Consecutive number of errors upon obtaining a lease
         displayName: Error On Lease Count
         path: errorOnLeaseCount
@@ -57,6 +60,9 @@ spec:
       - description: LastError represents the latest error if any in the latest reconciliation
         displayName: Last Error
         path: lastError
+      - description: The last time the status has been updated
+        displayName: Last Update
+        path: lastUpdate
       - description: PendingPods is a list of pending pods for eviction
         displayName: Pending Pods
         path: pendingPods

--- a/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -50,6 +50,9 @@ spec:
           status:
             description: NodeMaintenanceStatus defines the observed state of NodeMaintenance
             properties:
+              drainProgress:
+                description: Percentage completion of draining the node
+                type: integer
               errorOnLeaseCount:
                 description: Consecutive number of errors upon obtaining a lease
                 type: integer
@@ -60,6 +63,10 @@ spec:
               lastError:
                 description: LastError represents the latest error if any in the latest
                   reconciliation
+                type: string
+              lastUpdate:
+                description: The last time the status has been updated
+                format: date-time
                 type: string
               pendingPods:
                 description: PendingPods is a list of pending pods for eviction

--- a/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -49,6 +49,9 @@ spec:
           status:
             description: NodeMaintenanceStatus defines the observed state of NodeMaintenance
             properties:
+              drainProgress:
+                description: Percentage completion of draining the node
+                type: integer
               errorOnLeaseCount:
                 description: Consecutive number of errors upon obtaining a lease
                 type: integer
@@ -59,6 +62,10 @@ spec:
               lastError:
                 description: LastError represents the latest error if any in the latest
                   reconciliation
+                type: string
+              lastUpdate:
+                description: The last time the status has been updated
+                format: date-time
                 type: string
               pendingPods:
                 description: PendingPods is a list of pending pods for eviction

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -32,6 +32,9 @@ spec:
         displayName: Reason
         path: reason
       statusDescriptors:
+      - description: Percentage completion of draining the node
+        displayName: Drain Progress
+        path: drainProgress
       - description: Consecutive number of errors upon obtaining a lease
         displayName: Error On Lease Count
         path: errorOnLeaseCount
@@ -42,6 +45,9 @@ spec:
       - description: LastError represents the latest error if any in the latest reconciliation
         displayName: Last Error
         path: lastError
+      - description: The last time the status has been updated
+        displayName: Last Update
+        path: lastUpdate
       - description: PendingPods is a list of pending pods for eviction
         displayName: Pending Pods
         path: pendingPods

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -150,6 +150,7 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	updateOwnedLeaseFailed, err := r.obtainLease(node)
 	if err != nil && updateOwnedLeaseFailed {
+		setLastUpdate(instance)
 		instance.Status.ErrorOnLeaseCount += 1
 		if instance.Status.ErrorOnLeaseCount > MaxAllowedErrorToUpdateOwnedLease {
 			r.logger.Info("can't extend owned lease. uncordon for now")
@@ -164,10 +165,12 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.onReconcileError(instance, fmt.Errorf("Failed to extend lease owned by us : %v errorOnLeaseCount %d", err, instance.Status.ErrorOnLeaseCount))
 	}
 	if err != nil {
+		setLastUpdate(instance)
 		instance.Status.ErrorOnLeaseCount = 0
 		return r.onReconcileError(instance, err)
 	} else {
 		if instance.Status.Phase != nodemaintenancev1beta1.MaintenanceRunning || instance.Status.ErrorOnLeaseCount != 0 {
+			setLastUpdate(instance)
 			instance.Status.Phase = nodemaintenancev1beta1.MaintenanceRunning
 			instance.Status.ErrorOnLeaseCount = 0
 		}
@@ -192,7 +195,12 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	r.logger.Info("All pods evicted", "nodeName", nodeName)
 
+	// Calculate last update time when the drian is over - there are no more pending pods
+	if instance.Status.PendingPods != nil {
+		setLastUpdate(instance)
+	}
 	instance.Status.Phase = nodemaintenancev1beta1.MaintenanceSucceeded
+	instance.Status.DrainProgress = 100
 	instance.Status.PendingPods = nil
 	err = r.Client.Status().Update(context.TODO(), instance)
 	if err != nil {
@@ -388,6 +396,7 @@ func (r *NodeMaintenanceReconciler) fetchNode(nodeName string) (*corev1.Node, er
 func (r *NodeMaintenanceReconciler) initMaintenanceStatus(nm *nodemaintenancev1beta1.NodeMaintenance) error {
 	if nm.Status.Phase == "" {
 		nm.Status.Phase = nodemaintenancev1beta1.MaintenanceRunning
+		setLastUpdate(nm)
 		pendingList, errlist := r.drainer.GetPodsForDeletion(nm.Spec.NodeName)
 		if errlist != nil {
 			return fmt.Errorf("Failed to get pods for eviction while initializing status")
@@ -414,11 +423,15 @@ func (r *NodeMaintenanceReconciler) initMaintenanceStatus(nm *nodemaintenancev1b
 
 func (r *NodeMaintenanceReconciler) onReconcileErrorWithRequeue(nm *nodemaintenancev1beta1.NodeMaintenance, err error, duration *time.Duration) (reconcile.Result, error) {
 	nm.Status.LastError = err.Error()
+	setLastUpdate(nm)
 
 	if nm.Spec.NodeName != "" {
 		pendingList, _ := r.drainer.GetPodsForDeletion(nm.Spec.NodeName)
 		if pendingList != nil {
 			nm.Status.PendingPods = GetPodNameList(pendingList.Pods())
+			if nm.Status.EvictionPods != 0 {
+				nm.Status.DrainProgress = (nm.Status.EvictionPods - len(nm.Status.PendingPods)) * 100 / nm.Status.EvictionPods
+			}
 		}
 	}
 
@@ -437,6 +450,10 @@ func (r *NodeMaintenanceReconciler) onReconcileErrorWithRequeue(nm *nodemaintena
 func (r *NodeMaintenanceReconciler) onReconcileError(nm *nodemaintenancev1beta1.NodeMaintenance, err error) (reconcile.Result, error) {
 	return r.onReconcileErrorWithRequeue(nm, err, nil)
 
+}
+
+func setLastUpdate(nm *nodemaintenancev1beta1.NodeMaintenance) {
+	nm.Status.LastUpdate.Time = time.Now()
 }
 
 // writer implements io.Writer interface as a pass-through for klog.


### PR DESCRIPTION
Provide feedback for long running drain operations by adding two fields regarding their progress in the nodemaintenance CR status.

- Add two status fields, `DrainProgress` and `LastUpdate` , for gathering information about the drain progress and when the progress is stalled.
- Fix `maintanance` to `maintenance` appearances in the code,