### PR TITLE
Get version from image - must-gather

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=builder /usr/bin/oc /usr/bin/oc
 
 # Save original gather script
 COPY --from=builder /usr/bin/gather /usr/bin/gather_original
-COPY --from=builder /usr/bin/version /usr/bin/version
+COPY --from=builder /usr/bin/version /usr/bin/version_original
 
 # Copy our scripts
 COPY collection-scripts/* /usr/bin/

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -8,7 +8,7 @@ DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${DIR_NAME}/version
 echo "medik8s/node-maintenance-operator" > /must-gather/version # imageName - Source repo identifier
 version >> /must-gather/version # imageVersion  - Build version
-image_id >> /must-gather/version # imageID  -  repository@digest          
+imageId >> /must-gather/version # imageID  -  repository@digest          
 OPERATOR_NAME="node-maintenance"
 
 # Init named resource list, eg. ns/openshift-config

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -6,9 +6,9 @@ mkdir -p must-gather/operator-pod-logs/
 # Generate /must-gather/version file
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${DIR_NAME}/version
-echo "node-maintenance-operator/must-gather" > /must-gather/version
-version >> /must-gather/version
-
+echo "medik8s/node-maintenance-operator" > /must-gather/version # imageName - Source repo identifier
+version >> /must-gather/version # imageVersion  - Build version
+image_id >> /must-gather/version # imageID  -  repository@digest          
 OPERATOR_NAME="node-maintenance"
 
 # Init named resource list, eg. ns/openshift-config

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 function version() {
-  # get version from image (major.minor.micro, e.g. 4.11.0)
-  version=$( \
+  # get version from image (major.minor.micro, e.g. v4.11.0)
+  version=v$( \
     oc status | grep '^pod' | \
     sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' \
   )
@@ -14,4 +14,14 @@ function version() {
   [ -z "${version}" ] && version="Unknown"
 
   echo ${version}
+}
+
+function image_id() {
+   # get image id (e.g. repository@digest )
+  image_id=$(oc status | grep '^pod' | sed -r -e 's/^pod.*runs //' | awk '{print $2}')
+  
+  # if image_id is not found, use Unknown
+  [ -z "${image_id}" ] && image_id="Unknown"
+echo ${image_id}
+
 }

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
+export IMAGE=$( oc status | grep '^pod')
 
 function version() {
-  # Use OS_GIT_VERSION to get the version during build (major.minor.micro-patch_version, e.g. v4.11.0-1)
-  # https://github.com/openshift/must-gather/pull/327/files#r1036400571
-  version=$OS_GIT_VERSION
 
-# if OS_GIT_VERSION is not found, then get version from image (major.minor.micro, e.g. v4.11.0)
- [ -z "${version}" ] && version=v$( oc status | grep '^pod' | \
-    sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' \
-  )
+  # get version from image (major.minor.micro, e.g. v4.11.0)
+  version=v$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< $IMAGE)
 
   # if version is still not found, use 0.0.0-unknown
   [ -z "${version}" ] && version="0.0.0-unknown"
@@ -16,13 +12,13 @@ function version() {
   echo ${version}
 }
 
-function image_id() {
-   # get image id (e.g. repository@digest )
-  image_id=$(oc status | grep '^pod' | sed -r -e 's/^pod.*runs //' | awk '{print $2}')
+function imageId() {
+  # get image id (e.g. repository@digest )
+  imageId=$(sed -r -e 's/^pod.*runs //' <<< $IMAGE | awk '{print $2}')
   
   # if image_id is not found, use Unknown
-  [ -z "${image_id}" ] && image_id="Unknown-Image"
+  [ -z "${imageId}" ] && imageId="Unknown-Image"
   
-echo ${image_id}
+echo ${imageId}
 
 }

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -7,10 +7,10 @@ function version() {
     sed -n -r -e 's/.*([[:digit:]]+\.[[:digit:]]+(:?\.[[:digit:]])?(:?-[^@]+)?).*/\1/p' \
   )
 
-  # if version not found, fallback to imageID
+  # if version is not found, fallback to imageID
   [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
 
-  # if version still not found, use Unknown
+  # if version is still not found, use Unknown
   [ -z "${version}" ] && version="Unknown"
 
   echo ${version}

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 function version() {
-  # get version from image
+  # get version from image (major.minor.micro, e.g. 4.11.0)
   version=$( \
     oc status | grep '^pod' | \
-    sed -n -r -e 's/.*([[:digit:]]+\.[[:digit:]]+(:?\.[[:digit:]])?(:?-[^@]+)?).*/\1/p' \
+    sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' \
   )
 
   # if version is not found, fallback to imageID

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 function version() {
-  # get version from image (major.minor.micro, e.g. v4.11.0)
-  version=v$( \
-    oc status | grep '^pod' | \
+  # Use OS_GIT_VERSION to get the version during build (major.minor.micro-patch_version, e.g. v4.11.0-1)
+  # https://github.com/openshift/must-gather/pull/327/files#r1036400571
+  version=$OS_GIT_VERSION
+
+# if OS_GIT_VERSION is not found, then get version from image (major.minor.micro, e.g. v4.11.0)
+ [ -z "${version}" ] && version=v$( oc status | grep '^pod' | \
     sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' \
   )
 
-  # if version is not found, fallback to imageID
-  [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
-
-  # if version is still not found, use Unknown
-  [ -z "${version}" ] && version="Unknown"
+  # if version is still not found, use 0.0.0-unknown
+  [ -z "${version}" ] && version="0.0.0-unknown"
 
   echo ${version}
 }
@@ -21,7 +21,8 @@ function image_id() {
   image_id=$(oc status | grep '^pod' | sed -r -e 's/^pod.*runs //' | awk '{print $2}')
   
   # if image_id is not found, use Unknown
-  [ -z "${image_id}" ] && image_id="Unknown"
+  [ -z "${image_id}" ] && image_id="Unknown-Image"
+  
 echo ${image_id}
 
 }


### PR DESCRIPTION
According to the [must-gather enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/oc/must-gather.md#must-gather-images), there is a version file that indicates the product (first line) and the version (second line).

Currently the printed version is only in y.z format, due to regular expression, when y and z are one digit each. Resulting in "1.0" version for `registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v4.11.0`, rather than "4.11.0".

Fix bug https://issues.redhat.com/browse/ECOPROJECT-983