### PR TITLE
Update PDB API- 1.25 depreciation

### DIFF
--- a/test/manifests/fake-etcd-quorum-guard.yaml
+++ b/test/manifests/fake-etcd-quorum-guard.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: openshift-etcd
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   namespace: openshift-etcd


### PR DESCRIPTION
A follow up PR, after #17 PR.

> Updating PodDisruptionBudget API because of `policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1` (for more see [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125)).