### PR TITLE
PSA "restricted" - Pod Security Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,11 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
+.PHONY: bundle-k8s
+bundle-k8s: bundle # Generate bundle manifests and metadata for Kubernetes, then validate generated files.
+	$(KUSTOMIZE) build config/manifests-k8s | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(OPERATOR_SDK) bundle validate ./bundle
+
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -272,6 +272,9 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,6 +51,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manifests-k8s/kustomization.yaml
+++ b/config/manifests-k8s/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ../manifests
+
+patchesStrategicMerge:
+  - seccomp_patch.yaml

--- a/config/manifests-k8s/seccomp_patch.yaml
+++ b/config/manifests-k8s/seccomp_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      securityContext:
+        # Do not use SeccompProfile if your project must work on
+        # old k8s versions < 1.19 and OpenShift < 4.11
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
In order to comply with the restricted PSA profile, the pod needs to have `runAsNonRoot: true`, and all containers need to have `allowPrivilegeEscalation:false` and drop all capabilities.
Also the Dockerfile should set a USER.

On Kubernetes we would also need to set `seccompProfile.type: RuntimeDefault`.
This will be added by a new make target `bundle-k8s` for community (k8s) releases, since it  would break deployment on OCP 4.10 though. 
Therefore, it would be be empty by default.

Related docs:

- https://kubernetes.io/docs/concepts/security/pod-security-standards/
- https://kubernetes.io/docs/concepts/security/pod-security-admission/
- https://master.sdk.operatorframework.io/docs/best-practices/pod-security-standards/
- https://kubernetes.io/docs/setup/best-practices/enforcing-pod-security-standards/#adopt-a-multi-mode-strategy