### PR TITLE
Extend Bundle Validation with Three more Validators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,16 +310,15 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	$(MAKE) bundle-reset-date
-	## Validate the bundle directory with addinonal validtors, such as Kubernetes deprecated APIs based on bundle.CSV.Spec.MinKubeVersion
-	##  https://kubernetes.io/docs/reference/using-api/deprecation-guide/
-	$(OPERATOR_SDK) bundle validate ./bundle --select-optional suite=operatorframework
+	$(MAKE) bundle-reset-date bundle-validate
 
 .PHONY: bundle-k8s
 bundle-k8s: bundle # Generate bundle manifests and metadata for Kubernetes, then validate generated files.
 	$(KUSTOMIZE) build config/manifests-k8s | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	## Validate the bundle directory with addinonal validtors, such as Kubernetes deprecated APIs based on bundle.CSV.Spec.MinKubeVersion
-	##  https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+	$(MAKE) bundle-validate
+	
+.PHONY: bundle-validate
+bundle-validate: operator-sdk ## Validate the bundle directory with additional validators (suite=operatorframework), such as Kubernetes deprecated APIs (https://kubernetes.io/docs/reference/using-api/deprecation-guide/) based on bundle.CSV.Spec.MinKubeVersion
 	$(OPERATOR_SDK) bundle validate ./bundle --select-optional suite=operatorframework
 
 .PHONY: bundle-build

--- a/Makefile
+++ b/Makefile
@@ -311,12 +311,16 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(MAKE) bundle-reset-date
-	$(OPERATOR_SDK) bundle validate ./bundle
+	## Validate the bundle directory with addinonal validtors, such as Kubernetes deprecated APIs based on bundle.CSV.Spec.MinKubeVersion
+	##  https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+	$(OPERATOR_SDK) bundle validate ./bundle --select-optional suite=operatorframework
 
 .PHONY: bundle-k8s
 bundle-k8s: bundle # Generate bundle manifests and metadata for Kubernetes, then validate generated files.
 	$(KUSTOMIZE) build config/manifests-k8s | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	$(OPERATOR_SDK) bundle validate ./bundle
+	## Validate the bundle directory with addinonal validtors, such as Kubernetes deprecated APIs based on bundle.CSV.Spec.MinKubeVersion
+	##  https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+	$(OPERATOR_SDK) bundle validate ./bundle --select-optional suite=operatorframework
 
 .PHONY: bundle-build
 bundle-build: bundle-update ## Build the bundle image.


### PR DESCRIPTION
Running the operator-sdk validation without any flags validates the bundle format and conforms it's contents to what is allowed in a `registry+v1` bundle (see [ValidateBundleFormat and ValidateBundleContent](https://github.com/operator-framework/operator-sdk/blob/a5d933b5e8d729c9c3f9f1790f61053cf37dfafd/internal/cmd/operator-sdk/bundle/validate/validate.go#L163-L170) functions).

This PR extends our [bundle validation](https://sdk.operatorframework.io/docs/cli/operator-sdk_bundle_validate/) to three more [validators](https://github.com/operator-framework/operator-sdk/blob/a5d933b5e8d729c9c3f9f1790f61053cf37dfafd/internal/cmd/operator-sdk/bundle/validate/optional.go#L37-L81) (from `operatorframework` suite):

- **[operatorhub](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/operatorhub.go#L160)** validates the bundle manifests against the required criteria to publish
// the projects on OperatorHub.io.
- **[alpha-deprecated-apis](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/removed_apis.go#L55)** validates the bundle for [Kubernetes deprecated APIs](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) versions based on the [_bundle.CSV.Spec.MinKubeVersion_](https://github.com/medik8s/node-maintenance-operator/blob/main/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml#L345) value (and `--optional-values=k8s-version=K8S_VERSION` if provided) . 
The validation will error if it knows you are using a deprecated API and warn if it thinks there could be a deprecated API being used. Currently, _operator-sdk v1.26.0_, it supports only three [deprecated Kubernetes API versions](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/removed_apis.go#L30).
- **[good-practices](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/good_practices.go#L41)** validates the bundle against criteria and suggestions defined as good practices for bundles under the [operator-framework solutions](https://sdk.operatorframework.io/docs/best-practices/).


To see more options for using the bundle validation - Please run `operator-sdk bundle validate --list-optional`
