### PR TITLE
Run Github CI on Ubuntu 22.04

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   push-images:
     name: Build and push images to quay.io/medik8s
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -12,7 +12,7 @@ on: # on events
 jobs: # jobs to run
   build:
     name: Test and build PRs
-    runs-on: ubuntu-20.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+    runs-on: ubuntu-22.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
There is a newer [hosted runner Ubuntu image for github-actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) - `ubuntu-20.04` -> `ubuntu-22.04`.