### PR TITLE
[WIP] Add Super Linter target and CI

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push versioned CSV and images for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push-community
+        run: VERSION="${GITHUB_REF_NAME//v/}" && export VERSION && export IMAGE_REGISTRY=quay.io/medik8s && make container-build-and-push-community
 
       - name: Create release with manifests
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -1,5 +1,10 @@
-# Understanding the workflow file - https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#understanding-the-workflow-file
+---
 name: Pre Submit # workflow name
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#understanding-the-workflow-file
+#
+
 on: # on events
   push:
     branches:
@@ -19,8 +24,11 @@ jobs: # jobs to run
       with:
         fetch-depth: 0
 
-    - name: Run checks and unit tests
+    - name: Run checks and unit tests on a container
       run: make check
 
+    - name: Lint Code Base
+      run: make lint
+    
     - name: Build images
       run: make container-build-community

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -26,7 +26,13 @@ jobs: # jobs to run
 
     - name: Run checks and unit tests on a container
       run: make check
-
+    
+    - name: Set up Go # https://github.com/actions/setup-go/blob/main/action.yml
+      uses: actions/setup-go@v4
+      with: 
+        go-version-file: 'go.mod' 
+        cache-dependency-path: 'go.sum' 
+    
     - name: Lint Code Base
       run: make lint
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Build the manager binary
 FROM quay.io/centos/centos:stream9 AS builder
-RUN dnf install git golang -y
+RUN dnf install git-2.40.1 golang-1.20 -y && dnf clean all -y
 
 # Ensurec orrect Go version
 ENV GO_VERSION=1.20
-RUN go install golang.org/dl/go${GO_VERSION}@latest
-RUN ~/go/bin/go${GO_VERSION} download
-RUN /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go
-RUN go version
+RUN go install golang.org/dl/go${GO_VERSION}@latest \
+    && ~/go/bin/go${GO_VERSION} download \
+    && /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go \
+    && go version
 
 WORKDIR /workspace
 
@@ -30,7 +30,7 @@ COPY .git/ .git/
 RUN ./hack/build.sh
 
 # Use ubi-micro as minimal base image to package the manager binary - https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-1
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ super-linter: ## Runs super linter locally (Supported Linters -> https://github.
 	docker run --rm \
 		-e RUN_LOCAL=true \
 		-e USE_FIND_ALGORITHM=true \
-		-e IGNORE_GITIGNORED_FILES=true \		
+		-e IGNORE_GITIGNORED_FILES=true \
 		-e LOG_LEVEL=NOTICE \
 		-e FILTER_REGEX_EXCLUDE="/vendor/|/bin/" \
 		-v $$(pwd):/tmp/lint \

--- a/Makefile
+++ b/Makefile
@@ -435,4 +435,4 @@ super-linter: ## Runs super linter locally (Supported Linters -> https://github.
 		-e FILTER_REGEX_EXCLUDE="/vendor/|/bin/" \
 		-v $$(pwd):/tmp/lint \
 		-w /tmp/lint \
-		github/super-linter:v5
+		github/super-linter:slim-v5

--- a/Makefile
+++ b/Makefile
@@ -182,11 +182,11 @@ fix-imports: sort-imports ## Sort imports
 	$(SORT_IMPORTS) -w .
 
 .PHONY: test
-test: test-no-verify verify-unchanged ## Generate and format code, run tests, generate manifests and bundle, and verify no uncommitted changes
-
-.PHONY: test-no-verify
-test-no-verify: manifests generate go-verify test-imports fmt vet envtest ginkgo ## Generate and format code, and run tests
+test: manifests generate envtest ginkgo ## Generate code, and run unit tests
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" $(GINKGO) -r --keep-going  --require-suite --vv ./api/... ./controllers/... --coverprofile cover.out
+
+.PHONY: lint
+lint: manifests generate go-verify fix-imports fmt vet super-linter verify-unchanged ## Generate and format code, fix the imports, verify unmodified files and run super-linter
 
 .PHONY: bundle-run
 export BUNDLE_RUN_NAMESPACE ?= openshift-operators
@@ -395,8 +395,8 @@ catalog-push: ## Push a catalog image.
 ##@ Targets used by CI
 
 .PHONY: check 
-check: ## Dockerized version of make test-no-verify
-	$(DOCKER_GO) "make test-no-verify"
+check: ## Dockerized version of make test
+	$(DOCKER_GO) "make test"
 
 .PHONY: verify-unchanged
 verify-unchanged: ## Verify there are no un-committed changes

--- a/Makefile
+++ b/Makefile
@@ -424,3 +424,15 @@ container-build-and-push-community: container-build-community container-push ## 
 .PHONY: cluster-functest 
 cluster-functest: ginkgo ## Run e2e tests in a real cluster
 	./hack/functest.sh $(GINKGO_VERSION)
+
+.PHONY: super-linter
+super-linter: ## Runs super linter locally (Supported Linters -> https://github.com/super-linter/super-linter#supported-linters
+	docker run --rm \
+		-e RUN_LOCAL=true \
+		-e USE_FIND_ALGORITHM=true \
+		-e IGNORE_GITIGNORED_FILES=true \		
+		-e LOG_LEVEL=NOTICE \
+		-e FILTER_REGEX_EXCLUDE="/vendor/|/bin/" \
+		-v $$(pwd):/tmp/lint \
+		-w /tmp/lint \
+		github/super-linter:v5

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ The node-maintenance-operator (**NMO**) is an operator generated from the [opera
 NMO was *previously* developed under [KubeVirt](https://github.com/kubevirt/node-maintenance-operator), and this repository is the up-to-date version of NMO.
 
 The purpose of this operator is to watch for new or deleted custom resources (CRs) called `NodeMaintenance` which indicate that a node in the cluster should either:
-  - `NodeMaintenance` CR created: move node into maintenance, cordon the node - set it as unschedulable, and evict the pods (which can be evicted) from that node.
-  - `NodeMaintenance` CR deleted: remove pod from maintenance and uncordon the node - set it as schedulable.
+
+- `NodeMaintenance` CR created: move node into maintenance, cordon the node - set it as unschedulable, and evict the pods (which can be evicted) from that node.
+- `NodeMaintenance` CR deleted: remove pod from maintenance and uncordon the node - set it as schedulable.
 
 > *Note*:  The current behavior of the operator is to mimic `kubectl drain <node name>`.
 
@@ -27,16 +28,18 @@ After every PR merge to `main` branch images were build and pushed to `quay.io`.
 For deployment of NMO using these images you need:
 
 - a running OpenShift cluster, or a Kubernetes cluster with Operator Lifecycle Manager (OLM) installed.
-- `operator-sdk` binary installed, see https://sdk.operatorframework.io/docs/installation/.
+- `operator-sdk` binary installed, see <https://sdk.operatorframework.io/docs/installation/>.
 - a valid `$KUBECONFIG` configured to access your cluster.
 
 Then run `operator-sdk run bundle quay.io/medik8s/node-maintenance-operator-bundle:latest`
 
 ### Deploy the last release version
-Click on `Install` in the Node Maintenance Operator page under [OperatorHub.io](https://operatorhub.io/operator/node-maintenance-operator), 
+
+Click on `Install` in the Node Maintenance Operator page under [OperatorHub.io](https://operatorhub.io/operator/node-maintenance-operator),
 and follow its instructions to install the [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/), and the operator.
 
 ### Build and deploy from sources
+
 Follow the instructions [here](https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/#3-deploy-your-operator-with-olm) for deploying the operator with OLM.
 > *Note*: Webhook cannot run using `make deploy`, because the volume mount of the webserver certificate is not found.
 
@@ -46,6 +49,7 @@ Follow the instructions [here](https://sdk.operatorframework.io/docs/building-op
 
 To set maintenance on a node a `NodeMaintenance` custom resource should be created.
 The `NodeMaintenance` CR spec contains:
+
 - nodeName: The name of the node which will be put into maintenance mode.
 - reason: The reason why the node will be under maintenance.
 
@@ -70,6 +74,7 @@ time="2022-02-24T11:58:20Z" level=info msg="Maintenance taints will be added to 
 time="2022-02-24T11:58:20Z" level=info msg="Applying medik8s.io/drain taint add on Node: node02"
 time="2022-02-24T11:58:20Z" level=info msg="Patching taints on Node: node02"
 2022-02-23T07:33:59.336Z INFO controller-runtime.manager.controller.nodemaintenance Evict all Pods from Node {"reconciler group": "nodemaintenance.medik8s.io", "reconciler kind": "NodeMaintenance", "name": "nodemaintenance-sample", "namespace": "", "nodeName": "node02"}
+<!-- markdownlint-disable-next-line MD013 -->
 E0223 07:33:59.498801 1 nodemaintenance_controller.go:449] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-node-tuning-operator/tuned-jrprj, openshift-dns/dns-default-kf6jj, openshift-dns/node-resolver-72jzb, openshift-image-registry/node-ca-czgc6, openshift-ingress-canary/ingress-canary-44tgv, openshift-machine-config-operator/machine-config-daemon-csv6c, openshift-monitoring/node-exporter-rzwhz, openshift-multus/multus-additional-cni-plugins-829bh, openshift-multus/multus-qwfc9, openshift-multus/network-metrics-daemon-pxt6n, openshift-network-diagnostics/network-check-target-qqcbr, openshift-sdn/sdn-s5cqx; deleting Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet: openshift-marketplace/nmo-downstream-8-8nms7
 I0223 07:33:59.500418 1 nodemaintenance_controller.go:449] evicting pod openshift-network-diagnostics/network-check-source-865d4b5578-n2cxg
 I0223 07:33:59.500790 1 nodemaintenance_controller.go:449] evicting pod openshift-ingress/router-default-7548cf6fb5-rgxrq
@@ -134,6 +139,7 @@ The phase is updated for each processing attempt on the CR.
 `totalPods` is the total number of pods, before the node entered maintenance mode.
 
 ## Debug
+
 ### Collecting cluster data with must-gather
 
 Use NMO's must-gather from [here](https://github.com/medik8s/node-maintenance-operator/tree/main/must-gather) to collect related debug data.
@@ -155,16 +161,16 @@ Use NMO's must-gather from [here](https://github.com/medik8s/node-maintenance-op
 
 For new minor releases:
 
-  - create and push the `release-0.y` branch.
-  - update OpenshiftCI with new branches!
+- create and push the `release-0.y` branch.
+- update OpenshiftCI with new branches!
 
 For every major / minor / patch release:
 
-  - create and push the `vx.y.z` tag.
-  - this should trigger CI to build and push new images
+- create and push the `vx.y.z` tag.
+- this should trigger CI to build and push new images
   - if it fails, the manual fallback is `VERSION=x.y.z make container-build-and-push-community`
-  - make the git tag a release in the GitHub UI.
+- make the git tag a release in the GitHub UI.
 
 ## Help
 
-Feel free to join our Google group to get more info - https://groups.google.com/g/medik8s
+Feel free to join our Google group to get more info - <https://groups.google.com/g/medik8s>

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -7,7 +7,7 @@ export TEST_NAMESPACE=node-maintenance-test
 # no colors in CI
 NO_COLOR=""
 set +e
-if ! which tput &>/dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
+if ! which tput &>/dev/null 2>&1 || [[ $(tput -T"$TERM" colors) -lt 8 ]]; then
     echo "Terminal does not seem to support colored output, disabling it"
     NO_COLOR="-noColor"
 fi
@@ -30,9 +30,9 @@ fi
 # --require-suite: If set, Ginkgo fails if there are ginkgo tests in a directory but no invocation of RunSpecs.
 # --no-color: If set, suppress color output in default reporter.
 # --vv: If set, emits with maximal verbosity - includes skipped and pending tests.
-./bin/ginkgo/$1/ginkgo -r --keep-going --require-suite $NO_COLOR --vv  ./test/e2e
+E2E_COMMAND=$(./bin/ginkgo/"$1"/ginkgo -r --keep-going --require-suite $NO_COLOR --vv  ./test/e2e)
 
-if [[ $? != 0 ]]; then
+if [[ "${E2E_COMMAND}" != 0 ]]; then
     echo "E2e tests FAILED"
     exit 1
 fi

--- a/hack/verify-unchanged.sh
+++ b/hack/verify-unchanged.sh
@@ -2,6 +2,6 @@
 
 if [[ -n "$(git status --porcelain .)" ]]; then
     echo "Uncommitted generated files. Run 'make check' and commit results."
-    echo "$(git status --porcelain .)"
+    git status --porcelain .
     exit 1
 fi

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-must-gather:4.12.0 AS builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
-RUN microdnf install tar rsync jq
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-860
+RUN microdnf install tar-6.1.15 rsync-3.2.7 jq-1.6 -y && microdnf clean all -y
 
 # Copy must-gather required binaries
 COPY --from=builder /usr/bin/oc /usr/bin/oc
@@ -13,4 +13,4 @@ COPY --from=builder /usr/bin/version /usr/bin/version_original
 # Copy our scripts
 COPY collection-scripts/* /usr/bin/
 
-ENTRYPOINT /usr/bin/gather
+ENTRYPOINT [ "/usr/bin/gather" ]

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -3,12 +3,12 @@
 You can use the `oc adm must-gather` command to collect information about your cluster.
 
 With the node-maintenance-must-gather image you can collect manifests and logs related to node maintenance:
-- Node objects 
+
+- Node objects
 - Custom Resource Definition
 - Node Maintenance Operator pod's logs (dismiss drained pods)
 - Custom Resources
 - Cluster's resource (CPU, and Memory) usage
-
 
 To collect this data, you must specify the extra image using the `--image` option.
 Example:

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -5,11 +5,11 @@ mkdir -p must-gather/operator-pod-logs/
 
 # Generate /must-gather/version file
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-. ${DIR_NAME}/version
+# shellcheck disable=SC1091
+source "${DIR_NAME}"/version
 echo "medik8s/node-maintenance-operator" > /must-gather/version # imageName - Source repo identifier
 version >> /must-gather/version # imageVersion  - Build version
 imageId >> /must-gather/version # imageID  -  repository@digest          
-OPERATOR_NAME="node-maintenance"
 
 # Init named resource list, eg. ns/openshift-config
 named_resources=()
@@ -30,10 +30,10 @@ group_resources+=(nodes)
 
 # NMO's CRD
 NMO_CRD=$(oc get crds -o jsonpath='{range .items[*]}{"crd/"}{.metadata.name}{"\n"}{end}' | grep 'nodemaintenance.medik8s' | sed -z 's/\n/ /g')
-named_resources+=(${NMO_CRD})
+named_resources+=("${NMO_CRD}")
 
 # NMO's running POD name
-NMO_PODS=($(oc get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' -n ${NMO_NAMESPACE}  | grep 'node-maintenance'))
+NMO_PODS=("$(oc get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' -n "${NMO_NAMESPACE}"  | grep 'node-maintenance')")
 
 # Node Maintenance CRs
 group_resources+=(nm)
@@ -44,9 +44,10 @@ group_resources_text=$(IFS=, ; echo "${group_resources[*]}")
 oc adm inspect --dest-dir must-gather --all-namespaces "${group_resources_text}"
 
 # Get pod's logs for only the running pods. Dismiss drained NMO pods
-for NMO_POD_NAME in ${NMO_PODS[@]}; 
-do  if  [ $(oc get pod ${NMO_POD_NAME} -n ${NMO_NAMESPACE} -o jsonpath='{.status.phase}') == "Running" ];
-then oc logs ${NMO_POD_NAME} -n ${NMO_NAMESPACE} > must-gather/operator-pod-logs/${NMO_POD_NAME}; fi; done
+for NMO_POD_NAME in "${NMO_PODS[@]}"; 
+do  POD_PHASE="$(oc get pod "${NMO_POD_NAME}" -n "${NMO_NAMESPACE}" -o jsonpath='{.status.phase}')"
+if  [ "${POD_PHASE}" == "Running" ];
+then oc logs "${NMO_POD_NAME}" -n "${NMO_NAMESPACE}" > must-gather/operator-pod-logs/"${NMO_POD_NAME}"; fi; done
 
 # Get cluster's resource (CPU and Memory) usage 
 oc adm top node --use-protocol-buffers > must-gather/cluster_resoruce_statistics

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -1,24 +1,25 @@
 #!/usr/bin/env bash
-export IMAGE=$( oc status | grep '^pod')
+IMAGE=$( oc status | grep '^pod')
+export IMAGE
 
 function version() {
 
   # get version from image (major.minor.micro, e.g. v4.11.0)
-  version=v$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< $IMAGE)
+  version=v$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< "$IMAGE")
 
   # if version is still not found, use 0.0.0-unknown
   [ -z "${version}" ] && version="0.0.0-unknown"
 
-  echo ${version}
+  echo "${version}"
 }
 
 function imageId() {
   # get image id (e.g. repository@digest )
-  imageId=$(sed -r -e 's/^pod.*runs //' <<< $IMAGE | awk '{print $2}')
+  imageId=$(sed -r -e 's/^pod.*runs //' <<< "$IMAGE" | awk '{print $2}')
   
   # if image_id is not found, use Unknown
   [ -z "${imageId}" ] && imageId="Unknown-Image"
   
-echo ${imageId}
+echo "${imageId}"
 
 }


### PR DESCRIPTION
## What has changed?

- Add and run multiple linters, using one big linter ([**Super Linter**](https://github.com/marketplace/actions/super-linter)). Linting will test our code base locally and will be run for each PR using _Pre Submit_ job.
- Use super-linter slim - https://github.com/super-linter/super-linter#slim-image
- Use `test` target for **unit-test** and `lint` target for the rest
- Fetch and verify Golang version prior to `make lint` by go.mod and go.sum files

## What and why to lint the code?

Linting is the automated checking of your source code for programmatic and stylistic errors. This is done by using a lint tool (otherwise known as linter). A lint tool is a basic static code analyzer.

The term linting originally comes from a Unix utility for C, and it is important to reduce errors and improve the overall quality of your code. Using lint tools can help you accelerate development and reduce costs by finding errors earlier.

## More about Super Linter

The **super-linter** finds issues and reports them to the console output. Fixes are suggested in the console output but not automatically fixed, and a status check will show up as failed on the pull request.
It includes [many linters](https://github.com/super-linter/super-linter#supported-linters) such as:

- [hadolint](https://github.com/hadolint/hadolint) for Dockerfile
- [golangci-lint](https://github.com/golangci/golangci-lint) for Golang
- [HTMLHint](https://github.com/htmlhint/HTMLHint) for HTML
- [eslint-plugin-jsonc](https://www.npmjs.com/package/eslint-plugin-jsonc) for json
- [markdownlint](https://github.com/igorshubovych/markdownlint-cli#readme) for markdown
- [YamlLint](https://github.com/adrienverge/yamllint) for YAML

To locally test specific files (and ignore the reset) please use the `FILTER_REGEX_INCLUDE` [environment variable](https://github.com/super-linter/super-linter#environment-variables) in the super-linter target on Makefile, e.g. for only linting files with names include _Makefile_ or _README.md_ append `-e FILTER_REGEX_INCLUDE="Makefile|README.md" \`.

In addition, we can [exclude directories or files based on regex](https://github.com/super-linter/super-linter/issues/768), e.g. `-e FILTER_REGEX_EXCLUDE="/vendor/"`

https://issues.redhat.com/browse/ECOPROJECT-1207