### PR TITLE
Automate GitHub release draft

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -49,12 +49,13 @@ jobs:
             ## Notable Changes
             
             * TODO
+            
             ## Release Artifacts
             
             ### Images
-            * Operator: quay.io/repository/medik8s/node-maintenance-operator:${{ github.ref_name }}
-            * Bundle: quay.io/repository/medik8s/node-maintenance-operator-bundle:${{ github.ref_name }}
-            * Catalog aka Index: quay.io/repository/medik8s/node-maintenance-operator-catalog:${{ github.ref_name }}
+            * Operator: quay.io/medik8s/node-maintenance-operator:${{ github.ref_name }}
+            * Bundle: quay.io/medik8s/node-maintenance-operator-bundle:${{ github.ref_name }}
+            * Catalog aka Index: quay.io/medik8s/node-maintenance-operator-catalog:${{ github.ref_name }}
             
             ### Source code and OLM manifests
             Please find the source code and the OLM manifests in the `Assets` section below.

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -25,9 +25,35 @@ jobs:
 
       - name: Build and push CSV 0.0.1 + latest images for PR merges to main
         if: ${{ github.ref_type != 'tag' }}
-        run: export IMAGE_REGISTRY=quay.io/medik8s && make container-build-and-push
+        run: export IMAGE_REGISTRY=quay.io/medik8s && make container-build-and-push-community
 
       - name: Build and push versioned CSV and images for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export IMAGE_REGISTRY=quay.io/medik8s && export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push
+        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push-community
+
+      - name: Create release with manifests
+        if: ${{ github.ref_type == 'tag' }}
+        # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
+        uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          body: |
+            # Node Maintenance Operator ${{ github.ref_name }}
+            
+            ## Notable Changes
+            
+            * TODO
+            ## Release Artifacts
+            
+            ### Images
+            * Operator: quay.io/repository/medik8s/node-maintenance-operator:${{ github.ref_name }}
+            * Bundle: quay.io/repository/medik8s/node-maintenance-operator-bundle:${{ github.ref_name }}
+            * Catalog aka Index: quay.io/repository/medik8s/node-maintenance-operator-catalog:${{ github.ref_name }}
+            
+            ### Source code and OLM manifests
+            Please find the source code and the OLM manifests in the `Assets` section below.
+          gzip: folders
+          files: >
+            Manifests:bundle/

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -6,6 +6,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   push-images:
     name: Build and push images to quay.io/medik8s

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -23,4 +23,4 @@ jobs: # jobs to run
       run: make check
 
     - name: Build images
-      run: make container-build
+      run: make container-build-community

--- a/Makefile
+++ b/Makefile
@@ -407,12 +407,20 @@ container-build: check ## Build containers
 	$(DOCKER_GO) "make bundle"
 	make docker-build bundle-build must-gather-build
 
+.PHONY: bundle-build-community
+bundle-build-community: bundle-community ## Run bundle community changes in CSV, and then build the bundle image.
+	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+.PHONY: container-build-community
+container-build-community: check  ## Build containers for community
+	$(DOCKER_GO) "make bundle-community"
+	make docker-build bundle-build-community must-gather-build
+
 .PHONY: container-push 
 container-push: docker-push bundle-push catalog-build catalog-push must-gather-push ## Push containers (NOTE: catalog can't be build before bundle was pushed)
 
-.PHONY: container-build-and-push
-container-build-and-push: container-build container-push ## Build and push all the four images to quay (docker, bundle, catalog, and must-gather).
-
+.PHONY: container-build-and-push-community
+container-build-and-push-community: container-build-community container-push ## Build four images, update CSV for community, and push all the images to Quay (docker, bundle, catalog, and must-gather).
 .PHONY: cluster-functest 
 cluster-functest: ginkgo ## Run e2e tests in a real cluster
 	./hack/functest.sh $(GINKGO_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ bundle-update: ## Update containerImage, createdAt, and icon fields in the bundl
 	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
 	sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
 	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
-	$(OPERATOR_SDK) bundle validate ./bundle
+	$(MAKE) bundle-validate
 
 .PHONY: bundle-reset-date
 bundle-reset-date: ## Reset bundle's createdAt

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For every major / minor / patch release:
 
   - create and push the `vx.y.z` tag.
   - this should trigger CI to build and push new images
-    - if it fails, the manual fallback is `VERSION=x.y.z make container-build container-push`
+  - if it fails, the manual fallback is `VERSION=x.y.z make container-build-and-push-community`
   - make the git tag a release in the GitHub UI.
 
 ## Help


### PR DESCRIPTION
Similar to NHC we add automation for the creation of Github Release upon Git tag creation.

[ECOPROJECT-1128](https://issues.redhat.com//browse/ECOPROJECT-1128)