### PR TITLE
 Upgrade kube-rbac-proxy image to v0.15.0 and disable HTTP/2

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,9 +10,10 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
+        - "--http2-disable"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=0"


### PR DESCRIPTION
- update kube-rbac-proxy to v0.15.0
- disable HTTP/2 to prevent exploitation of CVE HTTP/2 Rapid Reset