### PR TITLE
NMO handling the new Exclude From remediation label on the node

### DIFF
--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -373,7 +373,7 @@ func (r *NodeMaintenanceReconciler) stopNodeMaintenanceOnDeletion(ctx context.Co
 			if err := r.LeaseManager.InvalidateLease(ctx, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}); err != nil {
 				return err
 			}
-			return r.removeExcludeRemediationLabel(ctx, node)
+			return nil
 		}
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4
-	github.com/medik8s/common v1.2.0
+	github.com/medik8s/common v1.11.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/medik8s/common v1.2.0 h1:xgQOijD3rEn+PfCd4lJuV3WFdt5QA6SIaqF01rRp2as=
-github.com/medik8s/common v1.2.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
+github.com/medik8s/common v1.11.0 h1:uw00Ej2aeRXG81zjfw9V69KRTyF47vBlSiV6eu8JipM=
+github.com/medik8s/common v1.11.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=

--- a/vendor/github.com/medik8s/common/pkg/labels/labels.go
+++ b/vendor/github.com/medik8s/common/pkg/labels/labels.go
@@ -7,4 +7,8 @@ const (
 	MasterRole = "node-role.kubernetes.io/master"
 	// ControlPlaneRole is the new role label of control plane nodes
 	ControlPlaneRole = "node-role.kubernetes.io/control-plane"
+	// DefaultTemplate label indicates to third party tools (e.g. UI) the default remediation template in case several exists.
+	DefaultTemplate = "remediation.medik8s.io/default-template"
+	// ExcludeFromRemediation label would be put on a node with value "true" in order to indicate this node should not be remediated.
+	ExcludeFromRemediation = "remediation.medik8s.io/exclude-from-remediation"
 )

--- a/vendor/github.com/medik8s/common/pkg/lease/manager.go
+++ b/vendor/github.com/medik8s/common/pkg/lease/manager.go
@@ -45,13 +45,13 @@ type manager struct {
 	log            logr.Logger
 }
 
-// AlreadyHeldError is returned in case the lease that is requested is already held by a different holder
+// AlreadyHeldError is returned in case the lease is already held by a different holder
 type AlreadyHeldError struct {
 	holderIdentity string
 }
 
-func (e *AlreadyHeldError) Error() string {
-	return fmt.Sprintf("can't update valid lease held by different owner: %s", e.holderIdentity)
+func (e AlreadyHeldError) Error() string {
+	return fmt.Sprintf("can't update or invalidate the lease because it is held by different owner: %s", e.holderIdentity)
 }
 
 func (l *manager) RequestLease(ctx context.Context, obj client.Object, leaseDuration time.Duration) error {
@@ -186,7 +186,7 @@ func (l *manager) requestLease(ctx context.Context, obj client.Object, leaseDura
 			if lease.Spec.HolderIdentity != nil {
 				identity = *lease.Spec.HolderIdentity
 			}
-			return &AlreadyHeldError{holderIdentity: identity}
+			return AlreadyHeldError{holderIdentity: identity}
 		}
 		needUpdateLease = true
 
@@ -226,6 +226,9 @@ func (l *manager) invalidateLease(ctx context.Context, obj client.Object) error 
 			return nil
 		}
 		return err
+	}
+	if lease.Spec.HolderIdentity != nil && l.holderIdentity != *lease.Spec.HolderIdentity {
+		return AlreadyHeldError{*lease.Spec.HolderIdentity}
 	}
 	if err := l.Client.Delete(ctx, lease); err != nil {
 		log.Error(err, "failed to delete lease to be invalidated")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,7 +128,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/medik8s/common v1.2.0
+# github.com/medik8s/common v1.11.0
 ## explicit; go 1.20
 github.com/medik8s/common/pkg/labels
 github.com/medik8s/common/pkg/lease


### PR DESCRIPTION
[ECOPROJECT-1747](https://issues.redhat.com//browse/ECOPROJECT-1747) , [ECOPROJECT-1779](https://issues.redhat.com//browse/ECOPROJECT-1779)

Supporting snr feature, making sure that once a node is put into maintenance by NMO it will apply the label which will cause SNR to stop running on that node.
This functionality is required for use cases where we would like to disable SNR (for example Node maintenance).