### PR TITLE
Set Suggested Namespace

### DIFF
--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -22,6 +22,7 @@ metadata:
     createdAt: ""
     description: Node Maintenance Operator for cordoning and draining nodes.
     olm.skipRange: '>=0.12.0'
+    operatorframework.io/suggested-namespace: openshift-workload-availability
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/node-maintenance-operator

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -23,6 +23,7 @@ metadata:
     description: Node Maintenance Operator for cordoning and draining nodes.
     olm.skipRange: '>=0.12.0'
     operatorframework.io/suggested-namespace: openshift-workload-availability
+    operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/node-maintenance-operator

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -10,6 +10,7 @@ metadata:
     description: Node Maintenance Operator for cordoning and draining nodes.
     olm.skipRange: '>=0.12.0'
     operatorframework.io/suggested-namespace: openshift-workload-availability
+    operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
     repository: https://github.com/medik8s/node-maintenance-operator
     support: Medik8s
   name: node-maintenance-operator.v0.0.0

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -9,6 +9,7 @@ metadata:
     createdAt: ""
     description: Node Maintenance Operator for cordoning and draining nodes.
     olm.skipRange: '>=0.12.0'
+    operatorframework.io/suggested-namespace: openshift-workload-availability
     repository: https://github.com/medik8s/node-maintenance-operator
     support: Medik8s
   name: node-maintenance-operator.v0.0.0


### PR DESCRIPTION
The suggested namespace is used to resolve the confusion of installing the operator from the console vs CLI.
We use two new [OCP annotations](https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-other_osdk-generating-csvs) for this matter and to make sure that `"openshift.io/node-selector":""` annotation is set on the installed namespace.


Similar to https://github.com/medik8s/self-node-remediation/pull/165, https://github.com/medik8s/self-node-remediation/pull/168 and related to [ECOPROJECT-1778](https://issues.redhat.com//browse/ECOPROJECT-1778)