### PR TITLE
Set Replace Annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,13 +198,14 @@ bundle-run: operator-sdk ## Run bundle image. Default NS is "openshift-operators
 ## Some addition to bundle creation in the bundle
 DEFAULT_ICON_BASE64 := $(shell base64 --wrap=0 ./config/assets/nmo_blue_icon.png)
 export ICON_BASE64 ?= ${DEFAULT_ICON_BASE64}
+export BUNDLE_CSV ?= "./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml"
 
 .PHONY: bundle-update
 bundle-update: verify-previous-version ## Update CSV fields and validate the bundle directory
-	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
-	sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
-	sed -r -i "s|replaces: .*|replaces: self-node-remediation.v${PREVIOUS_VERSION}|;" ${BUNDLE_CSV}
-	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
+	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ${BUNDLE_CSV}
+	sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ${BUNDLE_CSV}
+	sed -r -i "s|replaces: .*|replaces: $(OPERATOR_NAME)-operator.v${PREVIOUS_VERSION}|;" ${BUNDLE_CSV}
+	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ${BUNDLE_CSV}
 	$(MAKE) bundle-validate
 
 .PHONY: verify-previous-version
@@ -216,11 +217,11 @@ verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set
 
 .PHONY: bundle-reset-date
 bundle-reset-date: ## Reset bundle's createdAt
-	sed -r -i "s|createdAt: .*|createdAt: \"\"|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
+	sed -r -i "s|createdAt: .*|createdAt: \"\"|;" ${BUNDLE_CSV}
 
 .PHONY: bundle-community
 bundle-community: bundle-k8s ## Update displayName, and description fields in the bundle's CSV
-	sed -r -i "s|displayName: Node Maintenance Operator|displayName: Node Maintenance Operator - Community Edition |;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
+	sed -r -i "s|displayName: Node Maintenance Operator|displayName: Node Maintenance Operator - Community Edition |;" ${BUNDLE_CSV}
 	$(MAKE) bundle-update
 
 ##@ Build

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ export DEFAULT_CHANNEL
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= $(DEFAULT_VERSION)
+PREVIOUS_VERSION ?= $(DEFAULT_VERSION)
 export VERSION
 
 # CHANNELS define the bundle channels used in the bundle.
@@ -199,11 +200,19 @@ DEFAULT_ICON_BASE64 := $(shell base64 --wrap=0 ./config/assets/nmo_blue_icon.png
 export ICON_BASE64 ?= ${DEFAULT_ICON_BASE64}
 
 .PHONY: bundle-update
-bundle-update: ## Update containerImage, createdAt, and icon fields in the bundle's CSV
+bundle-update: verify-previous-version ## Update CSV fields and validate the bundle directory
 	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
 	sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
+	sed -r -i "s|replaces: .*|replaces: self-node-remediation.v${PREVIOUS_VERSION}|;" ${BUNDLE_CSV}
 	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ./bundle/manifests/$(OPERATOR_NAME)-operator.clusterserviceversion.yaml
 	$(MAKE) bundle-validate
+
+.PHONY: verify-previous-version
+verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set
+	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && [ $(PREVIOUS_VERSION) = $(DEFAULT_VERSION) ]; then \
+  			echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
+    		exit 1; \
+    fi
 
 .PHONY: bundle-reset-date
 bundle-reset-date: ## Reset bundle's createdAt

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -344,6 +344,7 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
+  replaces: node-maintenance-operator.v0.0.1
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -99,4 +99,5 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
+  replaces: node-maintenance-operator.v0.0.1
   version: 0.0.0


### PR DESCRIPTION
Even though we use 'skipRange' for defining from which versions we can update to the version of the CSV, we also need to add the 'replace' field. It should point to the last released version and ensure that the old version isn't deleted from the index.

https://docs.engineering.redhat.com/display/CFC/Best_Practices#Best_Practices-SkipRange

Similar to https://github.com/medik8s/self-node-remediation/pull/167 and related to [ECOPROJECT-1771](https://issues.redhat.com//browse/ECOPROJECT-1771)