### PR TITLE
Fix must-gather repo location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
 
-MUST_GATHER_IMAGE ?= $(IMAGE_TAG_BASE)-must-gather:$(IMAGE_TAG)
+MUST_GATHER_IMAGE ?= node-maintenance-must-gather:$(IMAGE_TAG)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)


### PR DESCRIPTION
The must-gather repo on quay is node-maintenance-must-gather and not node-maintenance-opreator-must-gather. This problem led to calling [`must-gather-push`](https://github.com/medik8s/node-maintenance-operator/blob/main/Makefile#L253-L255) target and failing for pushing the new image to quay.

> docker push quay.io/medik8s/node-maintenance-operator-must-gather:latest
> The push refers to repository [quay.io/medik8s/nod
> .
> .
> .
> unauthorized: access to the requested resource is not authorized
> make: *** [Makefile:255: must-gather-push] Error 1