### PR TITLE
Minor Reconcile Refactor 

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -95,7 +95,7 @@ var _ = BeforeSuite(func() {
 		logger:       ctrl.Log.WithName("unit test"),
 	}
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
-	drainer, err = createDrainer(cfg, ctx)
+	drainer, err = createDrainer(ctx, cfg)
 	Expect(err).NotTo(HaveOccurred())
 	// in test pods are not evicted, so don't wait forever for them
 	drainer.SkipWaitForDeleteTimeoutSeconds = 0

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/drain"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -47,6 +48,7 @@ var (
 	ctx       context.Context
 	cancel    context.CancelFunc
 	r         *NodeMaintenanceReconciler
+	drainer   *drain.Helper
 )
 
 func TestControllers(t *testing.T) {
@@ -88,19 +90,21 @@ var _ = BeforeSuite(func() {
 	r = &NodeMaintenanceReconciler{
 		Client:       k8sClient,
 		Scheme:       scheme.Scheme,
+		MgrConfig:    cfg,
 		LeaseManager: &mockLeaseManager{mockManager},
 		logger:       ctrl.Log.WithName("unit test"),
 	}
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
-	Expect(initDrainer(r, cfg, ctx)).To(Succeed())
+	drainer, err = createDrainer(cfg, ctx)
+	Expect(err).NotTo(HaveOccurred())
 	// in test pods are not evicted, so don't wait forever for them
-	r.drainer.SkipWaitForDeleteTimeoutSeconds = 0
+	drainer.SkipWaitForDeleteTimeoutSeconds = 0
 
-	err = (r).SetupWithManager(ctx, k8sManager)
+	err = r.SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
 		Expect(k8sManager.Start(ctx)).To(Succeed())
 	}()
 })

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -91,16 +91,16 @@ var _ = BeforeSuite(func() {
 		LeaseManager: &mockLeaseManager{mockManager},
 		logger:       ctrl.Log.WithName("unit test"),
 	}
-	Expect(initDrainer(r, cfg)).To(Succeed())
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
+	Expect(initDrainer(r, cfg, ctx)).To(Succeed())
 	// in test pods are not evicted, so don't wait forever for them
 	r.drainer.SkipWaitForDeleteTimeoutSeconds = 0
 
-	err = (r).SetupWithManager(k8sManager)
+	err = (r).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {
-		// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
-		ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 		Expect(k8sManager.Start(ctx)).To(Succeed())
 	}()
 })

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Status was initalized", func() {
 				It("should be set for running with 2 pods to drain", func() {
-					Expect(initMaintenanceStatus(nm, r.drainer, ctx, r.Client)).To(HaveOccurred())
+					Expect(initMaintenanceStatus(nm, drainer, ctx, r.Client)).To(HaveOccurred())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					Expect(nm.Status.Phase).To(Equal(v1beta1.MaintenanceRunning))
 					Expect(len(nm.Status.PendingPods)).To(Equal(2))
@@ -78,7 +78,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Owner ref was set", func() {
 				It("should be set properly", func() {
-					Expect(initMaintenanceStatus(nm, r.drainer, ctx, r.Client)).To(HaveOccurred())
+					Expect(initMaintenanceStatus(nm, drainer, ctx, r.Client)).To(HaveOccurred())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					By("Setting owner ref for a modified nm CR")
 					node := &corev1.Node{}
@@ -101,7 +101,7 @@ var _ = Describe("Node Maintenance", func() {
 				It("Should not modify the CR after initalization", func() {
 					nmCopy := nm.DeepCopy()
 					nmCopy.Status.Phase = v1beta1.MaintenanceFailed
-					Expect(initMaintenanceStatus(nmCopy, r.drainer, ctx, r.Client)).To(Succeed())
+					Expect(initMaintenanceStatus(nmCopy, drainer, ctx, r.Client)).To(Succeed())
 					// status was not initialized thus the function succeeds
 					Expect(nmCopy.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
 					Expect(len(nmCopy.Status.PendingPods)).To(Equal(0))
@@ -151,12 +151,12 @@ var _ = Describe("Node Maintenance", func() {
 					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, node)).To(Succeed())
 					Expect(isTaintExist(node, medik8sDrainTaint.Key, medik8sDrainTaint.Effect)).To(BeFalse())
 					By("Adding drain taint")
-					Expect(AddOrRemoveTaint(r.drainer.Client, true, node, ctx)).To(Succeed())
+					Expect(AddOrRemoveTaint(drainer.Client, true, node, ctx)).To(Succeed())
 					taintedNode := &corev1.Node{}
 					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, taintedNode)).To(Succeed())
 					Expect(isTaintExist(taintedNode, medik8sDrainTaint.Key, medik8sDrainTaint.Effect)).To(BeTrue())
 					By("Removing drain taint")
-					Expect(AddOrRemoveTaint(r.drainer.Client, false, taintedNode, ctx)).To(Succeed())
+					Expect(AddOrRemoveTaint(drainer.Client, false, taintedNode, ctx)).To(Succeed())
 					unTaintedNode := &corev1.Node{}
 					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, unTaintedNode)).To(Succeed())
 					Expect(isTaintExist(unTaintedNode, medik8sDrainTaint.Key, medik8sDrainTaint.Effect)).To(BeFalse())

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Status was initalized", func() {
 				It("should be set for running with 2 pods to drain", func() {
-					Expect(initMaintenanceStatus(nm, drainer, ctx, r.Client)).To(HaveOccurred())
+					Expect(initMaintenanceStatus(ctx, nm, drainer, r.Client)).To(HaveOccurred())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					Expect(nm.Status.Phase).To(Equal(v1beta1.MaintenanceRunning))
 					Expect(len(nm.Status.PendingPods)).To(Equal(2))
@@ -78,7 +78,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Owner ref was set", func() {
 				It("should be set properly", func() {
-					Expect(initMaintenanceStatus(nm, drainer, ctx, r.Client)).To(HaveOccurred())
+					Expect(initMaintenanceStatus(ctx, nm, drainer, r.Client)).To(HaveOccurred())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					By("Setting owner ref for a modified nm CR")
 					node := &corev1.Node{}
@@ -101,7 +101,7 @@ var _ = Describe("Node Maintenance", func() {
 				It("Should not modify the CR after initalization", func() {
 					nmCopy := nm.DeepCopy()
 					nmCopy.Status.Phase = v1beta1.MaintenanceFailed
-					Expect(initMaintenanceStatus(nmCopy, drainer, ctx, r.Client)).To(Succeed())
+					Expect(initMaintenanceStatus(ctx, nmCopy, drainer, r.Client)).To(Succeed())
 					// status was not initialized thus the function succeeds
 					Expect(nmCopy.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
 					Expect(len(nmCopy.Status.PendingPods)).To(Equal(0))
@@ -124,13 +124,13 @@ var _ = Describe("Node Maintenance", func() {
 					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, node)).To(Succeed())
 					Expect(len(node.Labels)).To(Equal(1))
 					By("Adding exclude remediation label")
-					Expect(addExcludeRemediationLabel(node, r.Client, ctx, testLog)).To(Succeed())
+					Expect(addExcludeRemediationLabel(ctx, node, r.Client, testLog)).To(Succeed())
 					labeledNode := &corev1.Node{}
 					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, labeledNode)).To(Succeed())
 					Expect(isLabelExist(labeledNode, commonLabels.ExcludeFromRemediation)).To(BeTrue())
 					Expect(len(labeledNode.Labels)).To(Equal(2))
 					By("Removing exclude remediation label")
-					Expect(removeExcludeRemediationLabel(node, r.Client, ctx, testLog)).To(Succeed())
+					Expect(removeExcludeRemediationLabel(ctx, node, r.Client, testLog)).To(Succeed())
 					unlabeledNode := &corev1.Node{}
 					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, unlabeledNode)).To(Succeed())
 					Expect(isLabelExist(unlabeledNode, commonLabels.ExcludeFromRemediation)).To(BeFalse())

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Node Maintenance", func() {
 
 				By("Check node taints")
 				Expect(isTaintExist(node, medik8sDrainTaint.Key, corev1.TaintEffectNoSchedule)).To(BeTrue())
-				Expect(isTaintExist(node, NodeUnschedulableTaint.Key, corev1.TaintEffectNoSchedule)).To(BeTrue())
+				Expect(isTaintExist(node, nodeUnschedulableTaint.Key, corev1.TaintEffectNoSchedule)).To(BeTrue())
 
 				By("Check add/remove Exclude remediation label")
 				// Label added on CR creation

--- a/controllers/taint.go
+++ b/controllers/taint.go
@@ -29,8 +29,7 @@ var nodeUnschedulableTaint = &corev1.Taint{
 }
 var maintenanceTaints = []corev1.Taint{*nodeUnschedulableTaint, *medik8sDrainTaint}
 
-func AddOrRemoveTaint(clientset kubernetes.Interface, node *corev1.Node, add bool) error {
-
+func AddOrRemoveTaint(clientset kubernetes.Interface, add bool, node *corev1.Node, ctx context.Context) error {
 	taintStr := ""
 	patch := ""
 	client := clientset.CoreV1().Nodes()
@@ -70,7 +69,7 @@ func AddOrRemoveTaint(clientset kubernetes.Interface, node *corev1.Node, add boo
 
 	test := fmt.Sprintf(`{ "op": "test", "path": "/spec/taints", "value": %s }`, string(oldTaints))
 	log.Infof("Patching taints on Node: %s", node.Name)
-	_, err = client.Patch(context.Background(), node.Name, types.JSONPatchType, []byte(fmt.Sprintf("[ %s, %s ]", test, patch)), v1.PatchOptions{})
+	_, err = client.Patch(ctx, node.Name, types.JSONPatchType, []byte(fmt.Sprintf("[ %s, %s ]", test, patch)), v1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("patching node taints failed: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -126,8 +126,9 @@ func main() {
 	if err = (&controllers.NodeMaintenanceReconciler{
 		Client:       cl,
 		Scheme:       mgr.GetScheme(),
+		MgrConfig:    mgr.GetConfig(),
 		LeaseManager: leaseManagerInitializer,
-	}).SetupWithManager(context.TODO(), mgr); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeMaintenance")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 		Client:       cl,
 		Scheme:       mgr.GetScheme(),
 		LeaseManager: leaseManagerInitializer,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.TODO(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeMaintenance")
 		os.Exit(1)
 	}


### PR DESCRIPTION
- Informative maintenance log message. 
- Use commonLabels, private variables instead of public. Refactor variable name and import API name.
- Refactor Finalizer handling with controllerutil
- Refactor reconcile.result replace deprecated k8s.io/utils/pointer package
- Use the Reconcile context (ctx) and also pass it between functions for get/update calls.
- Create drain Helper per each reconcile