### PR TITLE
Update and Upgrade Bundle Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,12 @@ test-no-verify: go-verify manifests generate fmt fix-imports vet envtest ginkgo 
 bundle-run: operator-sdk ## Run bundle image. Default NS is "openshift-workload-availability", redefine OPERATOR_NAMESPACE to override it.
 	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) run bundle $(BUNDLE_IMG)
 
+.PHONY: bundle-run-update
+bundle-run-update: operator-sdk ## Update bundle image. 
+# An older bundle image CSV should exist in the cluster, and in the same namespace,
+# Default NS is "openshift-workload-availability", redefine OPERATOR_NAMESPACE to override it.
+	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) run bundle-upgrade $(BUNDLE_IMG)
+
 .PHONY: bundle-cleanup
 bundle-cleanup: operator-sdk ## Remove bundle installed via bundle-run
 	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) cleanup $(OPERATOR_NAME)


### PR DESCRIPTION
Introduce a new target, `bundle-run-update`, for testing an operator upgrade.
It could be used as well for downgrading or reinstalling the operator (instead of running the _bundle-cleanup_ and then _bundle-run_).

### How to test it?

Run `VERSION=SOME_VERSION` before running the _bundle-run_ or _bundle-run-update_ targets to modify the installed or replaced bundle CSV.
For example, running `VERSION=0.15.0 make bundle-run && VERSION=0.16.0 make bundle-run-update` would install NMO v0.15.0 and then replace it with NMO v0.16.0.

[ECOPROJECT-1082](https://issues.redhat.com//browse/ECOPROJECT-1082)