### PR TITLE
Add Eviction Timeout Field for Maintenance Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Follow the instructions [here](https://sdk.operatorframework.io/docs/building-op
 
 To set maintenance on a node a `NodeMaintenance` custom resource should be created.
 The `NodeMaintenance` CR spec contains:
+
+- evictionTimeout: The timeout for pods eviction by drain/delete before giving up. Zero means infinite, and the default value is 30s.
 - nodeName: The name of the node which will be put into maintenance mode.
 - reason: The reason why the node will be under maintenance.
 
@@ -58,6 +60,7 @@ kind: NodeMaintenance
 metadata:
   name: nodemaintenance-sample
 spec:
+  evictionTimeout: "30s"
   nodeName: node02
   reason: "Test node maintenance"
 

--- a/api/v1beta1/nodemaintenance_types.go
+++ b/api/v1beta1/nodemaintenance_types.go
@@ -45,6 +45,14 @@ type NodeMaintenanceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// EvictionTimeout is the timeout for pods eviction by drain/delete before giving up
+	// Zero means infinite
+	// Valid time units are "ms", "s", "m", "h".
+	// +kubebuilder:default:="30s"
+	// +kubebuilder:validation:Pattern="^(0|([0-9]+(\\.[0-9]+)?(ms|s|m|h)))$"
+	// +kubebuilder:validation:Type:=string
+	//+operator-sdk:csv:customresourcedefinitions:type=spec
+	EvictionTimeout metav1.Duration `json:"evictionTimeout,omitempty"`
 	// Node name to apply maintanance on/off
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	NodeName string `json:"nodeName"`

--- a/api/v1beta1/nodemaintenance_types.go
+++ b/api/v1beta1/nodemaintenance_types.go
@@ -53,10 +53,10 @@ type NodeMaintenanceSpec struct {
 	// +kubebuilder:validation:Type:=string
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	EvictionTimeout metav1.Duration `json:"evictionTimeout,omitempty"`
-	// Node name to apply maintanance on/off
+	// Node name to apply maintenance on/off
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	NodeName string `json:"nodeName"`
-	// Reason for maintanance
+	// Reason for maintenance
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	Reason string `json:"reason,omitempty"`
 }

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
             "name": "nodemaintenance-sample"
           },
           "spec": {
+            "evictionTimeout": "30s",
             "nodeName": "node02",
             "reason": "Test node maintenance"
           }
@@ -43,6 +44,11 @@ spec:
         name: nodemaintenances
         version: v1beta1
       specDescriptors:
+      - description: EvictionTimeout is the timeout for pods eviction by drain/delete
+          before giving up Zero means infinite Valid time units are "ms", "s", "m",
+          "h".
+        displayName: Eviction Timeout
+        path: evictionTimeout
       - description: Node name to apply maintanance on/off
         displayName: Node Name
         path: nodeName

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -49,10 +49,10 @@ spec:
           "h".
         displayName: Eviction Timeout
         path: evictionTimeout
-      - description: Node name to apply maintanance on/off
+      - description: Node name to apply maintenance on/off
         displayName: Node Name
         path: nodeName
-      - description: Reason for maintanance
+      - description: Reason for maintenance
         displayName: Reason
         path: reason
       statusDescriptors:

--- a/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -52,10 +52,10 @@ spec:
                 pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               nodeName:
-                description: Node name to apply maintanance on/off
+                description: Node name to apply maintenance on/off
                 type: string
               reason:
-                description: Reason for maintanance
+                description: Reason for maintenance
                 type: string
             required:
             - nodeName

--- a/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -43,6 +43,14 @@ spec:
           spec:
             description: NodeMaintenanceSpec defines the desired state of NodeMaintenance
             properties:
+              evictionTimeout:
+                default: 30s
+                description: |-
+                  EvictionTimeout is the timeout for pods eviction by drain/delete before giving up
+                  Zero means infinite
+                  Valid time units are "ms", "s", "m", "h".
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
+                type: string
               nodeName:
                 description: Node name to apply maintanance on/off
                 type: string

--- a/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -41,6 +41,14 @@ spec:
           spec:
             description: NodeMaintenanceSpec defines the desired state of NodeMaintenance
             properties:
+              evictionTimeout:
+                default: 30s
+                description: |-
+                  EvictionTimeout is the timeout for pods eviction by drain/delete before giving up
+                  Zero means infinite
+                  Valid time units are "ms", "s", "m", "h".
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
+                type: string
               nodeName:
                 description: Node name to apply maintanance on/off
                 type: string

--- a/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -50,10 +50,10 @@ spec:
                 pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               nodeName:
-                description: Node name to apply maintanance on/off
+                description: Node name to apply maintenance on/off
                 type: string
               reason:
-                description: Reason for maintanance
+                description: Reason for maintenance
                 type: string
             required:
             - nodeName

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -33,10 +33,10 @@ spec:
           "h".
         displayName: Eviction Timeout
         path: evictionTimeout
-      - description: Node name to apply maintanance on/off
+      - description: Node name to apply maintenance on/off
         displayName: Node Name
         path: nodeName
-      - description: Reason for maintanance
+      - description: Reason for maintenance
         displayName: Reason
         path: reason
       statusDescriptors:

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -28,6 +28,11 @@ spec:
         name: nodemaintenances
         version: v1beta1
       specDescriptors:
+      - description: EvictionTimeout is the timeout for pods eviction by drain/delete
+          before giving up Zero means infinite Valid time units are "ms", "s", "m",
+          "h".
+        displayName: Eviction Timeout
+        path: evictionTimeout
       - description: Node name to apply maintanance on/off
         displayName: Node Name
         path: nodeName

--- a/config/samples/nodemaintenance_v1beta1_nodemaintenance.yaml
+++ b/config/samples/nodemaintenance_v1beta1_nodemaintenance.yaml
@@ -3,5 +3,6 @@ kind: NodeMaintenance
 metadata:
   name: nodemaintenance-sample
 spec:
+  evictionTimeout: "30s"
   nodeName: node02
   reason: "Test node maintenance"

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/medik8s/common/pkg/lease"
 	. "github.com/onsi/ginkgo/v2"
@@ -95,7 +96,8 @@ var _ = BeforeSuite(func() {
 		logger:       ctrl.Log.WithName("unit test"),
 	}
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
-	drainer, err = createDrainer(ctx, cfg)
+	evictionTimeout := time.Duration(30)
+	drainer, err = createDrainer(ctx, evictionTimeout, cfg)
 	Expect(err).NotTo(HaveOccurred())
 	// in test pods are not evicted, so don't wait forever for them
 	drainer.SkipWaitForDeleteTimeoutSeconds = 0

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -52,7 +52,6 @@ const (
 	//lease consts
 	LeaseHolderIdentity = "node-maintenance"
 	LeaseDuration       = 3600 * time.Second
-	DrainerTimeout      = 30 * time.Second
 )
 
 // NodeMaintenanceReconciler reconciles a NodeMaintenance object
@@ -229,7 +228,7 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 }
 
 // createDrainer creates a drain.Helper struct for external cordon and drain API
-func createDrainer(ctx context.Context, evicitonTimeout time.Duration, mgrConfig *rest.Config) (*drain.Helper, error) {
+func createDrainer(ctx context.Context, evictionTimeout time.Duration, mgrConfig *rest.Config) (*drain.Helper, error) {
 	drainer := &drain.Helper{}
 
 	//Continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.
@@ -255,7 +254,7 @@ func createDrainer(ctx context.Context, evicitonTimeout time.Duration, mgrConfig
 	drainer.GracePeriodSeconds = -1
 
 	//The length of time to wait before giving up, zero means infinite
-	drainer.Timeout = evicitonTimeout
+	drainer.Timeout = evictionTimeout
 
 	cs, err := kubernetes.NewForConfig(mgrConfig)
 	if err != nil {

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -118,7 +118,7 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Add finalizer when object is created
-	drainer, err := createDrainer(ctx, r.MgrConfig)
+	drainer, err := createDrainer(ctx, nm.Spec.EvictionTimeout.Duration, r.MgrConfig)
 	if err != nil {
 		return emptyResult, err
 	}
@@ -229,7 +229,7 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 }
 
 // createDrainer creates a drain.Helper struct for external cordon and drain API
-func createDrainer(ctx context.Context, mgrConfig *rest.Config) (*drain.Helper, error) {
+func createDrainer(ctx context.Context, evicitonTimeout time.Duration, mgrConfig *rest.Config) (*drain.Helper, error) {
 	drainer := &drain.Helper{}
 
 	//Continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.
@@ -254,9 +254,8 @@ func createDrainer(ctx context.Context, mgrConfig *rest.Config) (*drain.Helper, 
 	//Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.
 	drainer.GracePeriodSeconds = -1
 
-	// TODO - add logical value or attach from the maintenance CR
 	//The length of time to wait before giving up, zero means infinite
-	drainer.Timeout = DrainerTimeout
+	drainer.Timeout = evicitonTimeout
 
 	cs, err := kubernetes.NewForConfig(mgrConfig)
 	if err != nil {

--- a/controllers/taint.go
+++ b/controllers/taint.go
@@ -56,7 +56,7 @@ func AddOrRemoveTaint(clientset kubernetes.Interface, add bool, node *corev1.Nod
 			return err
 		}
 		taintStr = "remove"
-		log.Infof("Maintenance taints  will be removed from node %s", node.Name)
+		log.Infof("Maintenance taints will be removed from node %s", node.Name)
 		patch = fmt.Sprintf(`{ "op": "replace", "path": "/spec/taints", "value": %s }`, string(removeTaints))
 	}
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
@@ -26,7 +27,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/medik8s/node-maintenance-operator/api/v1beta1"
 )
@@ -41,8 +42,10 @@ var (
 	// The ns for test deployments
 	testNsName    string
 	testNamespace *corev1.Namespace
-	//namespace leases are created in
+	// namespace leases are created in
 	leaseNs = "medik8s-leases"
+	// default eviction timeout (30s)
+	evicitonTimeout = time.Second * 50
 )
 
 var _ = BeforeSuite(func() {
@@ -52,7 +55,7 @@ var _ = BeforeSuite(func() {
 	testNsName = os.Getenv("TEST_NAMESPACE")
 	Expect(testNsName).ToNot(BeEmpty(), "TEST_NAMESPACE env var not set, can't start e2e test")
 	testNamespace = &corev1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: testNsName,
 		},
 	}
@@ -66,7 +69,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// wait until webhooks are up and running by trying to create a CR and ignoring unexpected errors
-	testCR := getNodeMaintenance("webhook-test", "some-not-existing-node-name")
+	testCR := getNodeMaintenance("webhook-test", "some-not-existing-node-name", evicitonTimeout)
 	_ = createCRIgnoreUnrelatedErrors(testCR)
 })
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- A clear description of the problem you are trying to solve -->
Adds a new Spec field for the pod's eviction timeout. Configurable pod's eviction drain/deletion timeout for the user, while previously it was set to 30s (the default value).

#### Changes made

- Updating API with the new field
- Using the new timeout field in the _createDrainer_ function in reconcile and UTs.
- Update nm sample
- Update Readme

#### Which issue(s) this PR fixes:

[ECOPROJECT-1668](https://issues.redhat.com//browse/ECOPROJECT-1668)

#### Test plan

Add e2e test for different `evicitonTimeout` values -  high (50s) vs. low (10s)