### PR TITLE
Separate nm status initalization from update

### DIFF
--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -148,13 +148,16 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return emptyResult, nil
 	}
 
-	if err = initMaintenanceStatus(ctx, nm, drainer); err != nil {
+	needUpdate, err := initMaintenanceStatus(ctx, nm, drainer)
+	if err != nil {
 		r.logger.Error(err, "Failed to initalize NodeMaintenance status")
 		return r.onReconcileError(ctx, nm, drainer, err)
 	}
-	if err = r.Client.Status().Update(ctx, nm); err != nil {
-		r.logger.Error(err, "Failed to update NodeMaintenance with \"Running\" status")
-		return r.onReconcileError(ctx, nm, drainer, err)
+	if needUpdate {
+		if err = r.Client.Status().Update(ctx, nm); err != nil {
+			r.logger.Error(err, "Failed to update NodeMaintenance with \"Running\" status")
+			return r.onReconcileError(ctx, nm, drainer, err)
+		}
 	}
 
 	nodeName := nm.Spec.NodeName
@@ -393,13 +396,15 @@ func (r *NodeMaintenanceReconciler) fetchNode(ctx context.Context, drainer *drai
 	return node, nil
 }
 
-func initMaintenanceStatus(ctx context.Context, nm *v1beta1.NodeMaintenance, drainer *drain.Helper) error {
+// initMaintenanceStatus initializes the nm CR status only at the first time, when phase is empty,
+// It returns a bool whether we should update the CR status and an error if it can't be initialized
+func initMaintenanceStatus(ctx context.Context, nm *v1beta1.NodeMaintenance, drainer *drain.Helper) (bool, error) {
 	if nm.Status.Phase == "" {
 		nm.Status.Phase = v1beta1.MaintenanceRunning
 		setLastUpdate(nm)
 		pendingList, errlist := drainer.GetPodsForDeletion(nm.Spec.NodeName)
 		if errlist != nil {
-			return fmt.Errorf("failed to get pods for eviction while initializing status")
+			return false, fmt.Errorf("failed to get pods for eviction while initializing status")
 		}
 		if pendingList != nil {
 			nm.Status.PendingPods = GetPodNameList(pendingList.Pods())
@@ -412,12 +417,12 @@ func initMaintenanceStatus(ctx context.Context, nm *v1beta1.NodeMaintenance, dra
 				FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nm.Spec.NodeName}).String(),
 			})
 		if err != nil {
-			return err
+			return false, err
 		}
 		nm.Status.TotalPods = len(podlist.Items)
-		return err
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func (r *NodeMaintenanceReconciler) onReconcileErrorWithRequeue(ctx context.Context, nm *v1beta1.NodeMaintenance, drainer *drain.Helper, err error, duration *time.Duration) (ctrl.Result, error) {

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -66,8 +66,9 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Status was initalized", func() {
 				It("should be set for running with 2 pods to drain", func() {
-					Expect(initMaintenanceStatus(ctx, nm, drainer)).Error().NotTo(HaveOccurred())
-					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
+					toUpdate, err := initMaintenanceStatus(ctx, nm, drainer)
+					Expect(toUpdate).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
 					Expect(nm.Status.Phase).To(Equal(v1beta1.MaintenanceRunning))
 					Expect(len(nm.Status.PendingPods)).To(Equal(2))
 					Expect(nm.Status.EvictionPods).To(Equal(2))
@@ -78,8 +79,9 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Owner ref was set", func() {
 				It("should be set properly", func() {
-					Expect(initMaintenanceStatus(ctx, nm, drainer)).Error().NotTo(HaveOccurred())
-					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
+					toUpdate, err := initMaintenanceStatus(ctx, nm, drainer)
+					Expect(toUpdate).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
 					By("Setting owner ref for a modified nm CR")
 					node := &corev1.Node{}
 					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, node)).To(Succeed())
@@ -101,8 +103,9 @@ var _ = Describe("Node Maintenance", func() {
 				It("Should not modify the CR after initalization", func() {
 					nmCopy := nm.DeepCopy()
 					nmCopy.Status.Phase = v1beta1.MaintenanceFailed
-					Expect(initMaintenanceStatus(ctx, nmCopy, drainer)).Error().NotTo(HaveOccurred())
-					// status was not initialized thus the function succeeds
+					toUpdate, err := initMaintenanceStatus(ctx, nmCopy, drainer)
+					Expect(toUpdate).To(BeFalse())
+					Expect(err).NotTo(HaveOccurred())
 					Expect(nmCopy.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
 					Expect(len(nmCopy.Status.PendingPods)).To(Equal(0))
 					Expect(nmCopy.Status.EvictionPods).To(Equal(0))

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Status was initalized", func() {
 				It("should be set for running with 2 pods to drain", func() {
-					Expect(initMaintenanceStatus(ctx, nm, drainer, r.Client)).To(HaveOccurred())
+					Expect(initMaintenanceStatus(ctx, nm, drainer)).To(Succeed())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					Expect(nm.Status.Phase).To(Equal(v1beta1.MaintenanceRunning))
 					Expect(len(nm.Status.PendingPods)).To(Equal(2))
@@ -78,7 +78,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Owner ref was set", func() {
 				It("should be set properly", func() {
-					Expect(initMaintenanceStatus(ctx, nm, drainer, r.Client)).To(HaveOccurred())
+					Expect(initMaintenanceStatus(ctx, nm, drainer)).To(Succeed())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					By("Setting owner ref for a modified nm CR")
 					node := &corev1.Node{}
@@ -101,7 +101,7 @@ var _ = Describe("Node Maintenance", func() {
 				It("Should not modify the CR after initalization", func() {
 					nmCopy := nm.DeepCopy()
 					nmCopy.Status.Phase = v1beta1.MaintenanceFailed
-					Expect(initMaintenanceStatus(ctx, nmCopy, drainer, r.Client)).To(Succeed())
+					Expect(initMaintenanceStatus(ctx, nmCopy, drainer)).To(Succeed())
 					// status was not initialized thus the function succeeds
 					Expect(nmCopy.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
 					Expect(len(nmCopy.Status.PendingPods)).To(Equal(0))

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Status was initalized", func() {
 				It("should be set for running with 2 pods to drain", func() {
-					Expect(initMaintenanceStatus(ctx, nm, drainer)).To(Succeed())
+					Expect(initMaintenanceStatus(ctx, nm, drainer)).Error().NotTo(HaveOccurred())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					Expect(nm.Status.Phase).To(Equal(v1beta1.MaintenanceRunning))
 					Expect(len(nm.Status.PendingPods)).To(Equal(2))
@@ -78,7 +78,7 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			When("Owner ref was set", func() {
 				It("should be set properly", func() {
-					Expect(initMaintenanceStatus(ctx, nm, drainer)).To(Succeed())
+					Expect(initMaintenanceStatus(ctx, nm, drainer)).Error().NotTo(HaveOccurred())
 					// status was initialized but the function will fail on updating the CR status, since we don't create a nm CR here
 					By("Setting owner ref for a modified nm CR")
 					node := &corev1.Node{}
@@ -101,7 +101,7 @@ var _ = Describe("Node Maintenance", func() {
 				It("Should not modify the CR after initalization", func() {
 					nmCopy := nm.DeepCopy()
 					nmCopy.Status.Phase = v1beta1.MaintenanceFailed
-					Expect(initMaintenanceStatus(ctx, nmCopy, drainer)).To(Succeed())
+					Expect(initMaintenanceStatus(ctx, nmCopy, drainer)).Error().NotTo(HaveOccurred())
 					// status was not initialized thus the function succeeds
 					Expect(nmCopy.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
 					Expect(len(nmCopy.Status.PendingPods)).To(Equal(0))


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- A clear description of the problem you are trying to solve -->
Take out the nm CR update from the initMaintenanceStatus function so the function can easily be tested (and succeeded) in UTs.
to only nm status initialization and update is done afterward. It is mostly needed for UTs of the initMaintenanceStatus function

#### Changes made
Separation of initMaintenanceStatus logic to only nm status initialization and update is done only afterwards. It is mostly needed for UTs of the initMaintenanceStatus function

#### Which issue(s) this PR fixes:

Follow up for [comment](https://github.com/medik8s/node-maintenance-operator/pull/118#discussion_r1494252479)
