### PR TITLE
Skip previous version validation in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ export DEFAULT_CHANNEL
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
+CI_VERSION := 9.9.9-dummy
 VERSION ?= $(DEFAULT_VERSION)
 PREVIOUS_VERSION ?= $(DEFAULT_VERSION)
 export VERSION
@@ -220,10 +221,10 @@ bundle-update: verify-previous-version ## Update CSV fields and validate the bun
 
 .PHONY: verify-previous-version
 verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set
-	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && [ $(PREVIOUS_VERSION) = $(DEFAULT_VERSION) ]; then \
-  			echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
-    		exit 1; \
-    fi
+	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && [ $(VERSION) != $(CI_VERSION) ] && [ $(PREVIOUS_VERSION) = $(DEFAULT_VERSION) ]; then \
+		echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
+    	exit 1; \
+	fi
 
 .PHONY: bundle-reset-date
 bundle-reset-date: ## Reset bundle's createdAt


### PR DESCRIPTION
#### Why we need this PR
Should fix an error when VERSION equals CI_VERSION, so it would skip the previous version validation in CI

Error in [post-submit automation](https://github.com/medik8s/node-maintenance-operator/actions/runs/8222640793/job/22484445513)

> make[1]: Entering directory '/home/go/src/github.com/medik8s/node-maintenance-operator'
> 924
> Error: PREVIOUS_VERSION must be set for the selected VERSION
>  VERSION equals CI_VERSION,
> 

#### Changes made

Modify the `verify-previous-version` target so it fails when VERSION doesn't equal CI_VERSION.
Similar to [SNR PR](https://github.com/medik8s/self-node-remediation/pull/179)