### PR TITLE
Verify previous version only when it is needed

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push versioned CSV and images for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && export DUMMY_VERSION="9.9.9-ci" && make container-build-and-push-community
+        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && export SKIP_VERIFY_PREVIOUS_VERSION="true" && make container-build-and-push-community
 
       - name: Create release with manifests
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push versioned CSV and images for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push-community
+        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && export DUMMY_VERSION="9.9.9-ci" && make container-build-and-push-community
 
       - name: Create release with manifests
         if: ${{ github.ref_type == 'tag' }}

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ export DEFAULT_CHANNEL
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-CI_VERSION := 9.9.9-dummy
+CI_VERSION := 9.9.9-ci
+DUMMY_VERSION ?= 9.9.9-dummy
 VERSION ?= $(DEFAULT_VERSION)
 PREVIOUS_VERSION ?= $(DEFAULT_VERSION)
 export VERSION
@@ -220,8 +221,9 @@ bundle-update: verify-previous-version ## Update CSV fields and validate the bun
 	$(MAKE) bundle-validate
 
 .PHONY: verify-previous-version
-verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set
-	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && [ $(VERSION) != $(CI_VERSION) ] && [ $(PREVIOUS_VERSION) = $(DEFAULT_VERSION) ]; then \
+verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set properly (but not in CI)
+	@if [[ ($(PREVIOUS_VERSION) != $(DEFAULT_VERSION) && $(PREVIOUS_VERSION) == $(VERSION)) ||\
+	 ($(PREVIOUS_VERSION) == $(DEFAULT_VERSION) && $(VERSION) != $(DEFAULT_VERSION) && $(DUMMY_VERSION) != $(CI_VERSION) ) ]]; then \
 		echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
     	exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,6 @@ export DEFAULT_CHANNEL
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-CI_VERSION := 9.9.9-ci
-DUMMY_VERSION ?= 9.9.9-dummy
 VERSION ?= $(DEFAULT_VERSION)
 PREVIOUS_VERSION ?= $(DEFAULT_VERSION)
 export VERSION
@@ -223,7 +221,7 @@ bundle-update: verify-previous-version ## Update CSV fields and validate the bun
 .PHONY: verify-previous-version
 verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set properly (but not in CI)
 	@if [[ ($(PREVIOUS_VERSION) != $(DEFAULT_VERSION) && $(PREVIOUS_VERSION) == $(VERSION)) ||\
-	 ($(PREVIOUS_VERSION) == $(DEFAULT_VERSION) && $(VERSION) != $(DEFAULT_VERSION) && $(DUMMY_VERSION) != $(CI_VERSION) ) ]]; then \
+	 ($(PREVIOUS_VERSION) == $(DEFAULT_VERSION) && $(VERSION) != $(DEFAULT_VERSION) && SKIP_VERIFY_PREVIOUS_VERSION == true ) ]]; then \
 		echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
     	exit 1; \
 	fi


### PR DESCRIPTION
#### Why we need this PR
Fix a problem that causes pushing tags to fail and pushing git tags to Quay.

#### Changes made
Now the target makes sure to fail on a bad PREVIOUS_VERSION value

- PREVIOUS_VERSION was set but it equals to VERSION
- PREVIOUS_VERSION wasn't set but VERSION was set (and we skip it in CI by setting the SKIP_VERIFY_PREVIOUS_VERSION in post-submit)

#### Which issue(s) this PR fixes
An issue with the `verify-previous-version` target that wasn't fixed properly in  #124

