### PR TITLE
Fix Github CI Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,15 +425,14 @@ bundle-build-community: bundle-community ## Run bundle community changes in CSV,
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: container-build-community
-container-build-community: check  ## Build containers for community
-	$(DOCKER_GO) "make bundle-community"
-	make docker-build bundle-build-community
+container-build-community: docker-build bundle-build-community ## Build containers for community
 
 .PHONY: container-push 
 container-push: docker-push bundle-push catalog-build catalog-push## Push containers (NOTE: catalog can't be build before bundle was pushed)
 
 .PHONY: container-build-and-push-community
 container-build-and-push-community: container-build-community container-push ## Build four images, update CSV for community, and push all the images to Quay (docker, bundle, and catalog).
+
 .PHONY: cluster-functest 
 cluster-functest: ginkgo ## Run e2e tests in a real cluster
 	./hack/functest.sh $(GINKGO_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -408,8 +408,8 @@ catalog-push: ## Push a catalog image.
 ##@ Targets used by CI
 
 .PHONY: check 
-check: ## Dockerized version of make test-no-verify
-	$(DOCKER_GO) "make test-no-verify"
+check: ## Dockerized version of make test
+	$(DOCKER_GO) "make test"
 
 .PHONY: verify-unchanged
 verify-unchanged: ## Verify there are no un-committed changes

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -51,7 +51,7 @@ const (
 	waitDurationOnDrainError          = 5 * time.Second
 	FixedDurationReconcileLog         = "Reconciling with fixed duration"
 	// An expected error from fetchNode function
-	expectedNodeNotFoundErrorMsg      = "nodes \"%s\" not found"
+	expectedNodeNotFoundErrorMsg = "nodes \"%s\" not found"
 
 	//lease consts
 	LeaseHolderIdentity = "node-maintenance"


### PR DESCRIPTION
#### Why we need this PR
CI test of unit-test failed due to redundant space/tab from #113.
In `check` target we use `test-no-verify` target that doesn't check for modified files, while it should use `test` target that won't accept modified files (using `verify-unchanged` target)
#### Changes made

- Use `test` instead of `test-no-verify` in `check` target
- Remove Redundant space/tab for a const var
- Remove multiple checks in dockerized NMO (for the `container-build-community` target) and as a result save time.

#### Which issue(s) this PR fixes
Fixes unit-test from `make test`. Found in https://github.com/openshift/release/pull/49534