### PR TITLE
Build Manager Binary in a Modular Way

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -9,7 +9,6 @@ BUILD_DATE=$(date --utc -Iseconds)
 mkdir -p bin
 
 LDFLAGS_VALUE="-X github.com/medik8s/node-maintenance-operator/version.Version=${VERSION} "
-# additional values must be quoted when used with GOFLAGS!
 LDFLAGS_VALUE+="-X github.com/medik8s/node-maintenance-operator/version.GitCommit=${COMMIT} "
 LDFLAGS_VALUE+="-X github.com/medik8s/node-maintenance-operator/version.BuildDate=${BUILD_DATE} "
 # allow override for debugging flags
@@ -27,8 +26,6 @@ export CGO_ENABLED=${CGO_ENABLED:-0}
 echo "cgo: ${CGO_ENABLED}"
 
 # export in case it was set
-if [ ! -z "${GOEXPERIMENT}" ]; then
-    export GOEXPERIMENT= $GOEXPERIMENT
-fi
+export GOEXPERIMENT= $GOEXPERIMENT
 
 GOOS=linux GOARCH=amd64 go build -o bin/manager main.go


### PR DESCRIPTION
<!-- Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
Allow default values for building Golang manager binary using build.sh, and support for other flags.

#### Changes made
<!-- Outline the specific changes made in this merge request. -->

- Build manager binary in a modular way

<!-- Thanks for contributing to our project! We appreciate your time and effort.

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->
Relates to [ECOPROJECT-1972](https://issues.redhat.com//browse/ECOPROJECT-1972)

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
