### PR TITLE
Extend Timeout for Events Verification on E2E Tests

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,7 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/medik8s/node-maintenance-operator/api/v1beta1"
 )
@@ -41,7 +41,7 @@ var (
 	// The ns for test deployments
 	testNsName    string
 	testNamespace *corev1.Namespace
-	//namespace leases are created in
+	// namespace leases are created in
 	leaseNs = "medik8s-leases"
 )
 
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 	testNsName = os.Getenv("TEST_NAMESPACE")
 	Expect(testNsName).ToNot(BeEmpty(), "TEST_NAMESPACE env var not set, can't start e2e test")
 	testNamespace = &corev1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: testNsName,
 		},
 	}

--- a/test/e2e/node_maintenance_test.go
+++ b/test/e2e/node_maintenance_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nmo "github.com/medik8s/node-maintenance-operator/api/v1beta1"
@@ -223,7 +223,6 @@ var _ = Describe("Starting Maintenance", func() {
 			waitForTestDeployment(1)
 
 		})
-
 	})
 })
 
@@ -253,14 +252,14 @@ func getNodes() ([]string, []string) {
 	return controlPlaneNodes, workers
 }
 
-func getNodeMaintenance(objectname, nodeName string) *nmo.NodeMaintenance {
+func getNodeMaintenance(name, nodeName string) *nmo.NodeMaintenance {
 	return &nmo.NodeMaintenance{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       maintenanceKind,
 			APIVersion: "nodemaintenance.medik8s.io/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: objectname,
+			Name: name,
 		},
 		Spec: nmo.NodeMaintenanceSpec{
 			NodeName: nodeName,
@@ -301,7 +300,7 @@ func createTestDeployment() {
 			Namespace: testNsName,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To[int32](1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: podLabel,
 			},
@@ -342,7 +341,7 @@ func createTestDeployment() {
 						Args:    []string{"-c", "while true; do echo hello; sleep 10;done"},
 					}},
 					// make sure we run into the drain timeout at least once
-					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(nodemaintenance.DrainerTimeout.Seconds()) + 50),
+					TerminationGracePeriodSeconds: ptr.To[int64](int64(nodemaintenance.DrainerTimeout.Seconds()) + 50),
 				},
 			},
 		},

--- a/test/e2e/node_maintenance_test.go
+++ b/test/e2e/node_maintenance_test.go
@@ -33,7 +33,8 @@ const (
 	testWorkerMaintenance = "test-maintenance"
 	retryInterval         = time.Second * 5
 	eventInterval         = time.Second * 10
-	timeout               = time.Second * 120
+	deploymentTimeout     = time.Second * 120
+	eventsTimeout         = time.Second * 180
 	testDeployment        = "test-deployment"
 )
 
@@ -373,7 +374,7 @@ func waitForTestDeployment(offset int) {
 		logInfoln("test deployment not available yet")
 		return fmt.Errorf("test deploymemt not ready yet")
 
-	}, timeout, retryInterval).ShouldNot(HaveOccurred(), "test deployment failed")
+	}, deploymentTimeout, retryInterval).ShouldNot(HaveOccurred(), "test deployment failed")
 
 }
 
@@ -463,7 +464,7 @@ func isLeaseInvalidated(nodeName string) {
 // by its name and reason
 func waitForEvent(ctx context.Context, eventReason, eventIdentifier string) error {
 	// Wait for events with a timeout
-	return wait.PollUntilContextTimeout(ctx, retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, retryInterval, eventsTimeout, true, func(ctx context.Context) (bool, error) {
 		events, err := KubeClient.CoreV1().Events("").List(ctx, metav1.ListOptions{
 			FieldSelector: fmt.Sprintf("involvedObject.kind=%s", maintenanceKind),
 		})


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->

- Fix the Flaky E2E test regarding an error in the missing succeeded maintenance event.
- Extend the verification timeout of existing/non-existing events from 120 sec to 180 sec, since successful event might happen after 2 minutes.

#### Changes made
<!-- Outline the specific changes made in this merge request. -->

- Extending events timeout from 120 sec to 180 sec.
- Small fixes and fixes to deprecated modules

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
