### PR TITLE
NamespacedName in PendingPods status field

### DIFF
--- a/api/v1beta1/nodemaintenance_types.go
+++ b/api/v1beta1/nodemaintenance_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -73,6 +74,9 @@ type NodeMaintenanceStatus struct {
 	// PendingPods is a list of pending pods for eviction
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	PendingPods []string `json:"pendingPods,omitempty"`
+	// PendingPodsRefs is a list of refs of pending pods for eviction
+	//+operator-sdk:csv:customresourcedefinitions:type=status
+	PendingPodsRefs []corev1.ObjectReference `json:"pendingPodsRefs,omitempty"`
 	// TotalPods is the total number of all pods on the node from the start
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	TotalPods int `json:"totalpods,omitempty"`

--- a/api/v1beta1/nodemaintenance_types.go
+++ b/api/v1beta1/nodemaintenance_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,6 +53,17 @@ type NodeMaintenanceSpec struct {
 	Reason string `json:"reason,omitempty"`
 }
 
+type PodReference struct {
+	// Namespace of the referent pod.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+	// +optional
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
+	// Name of the referent pod.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +optional
+	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
+}
+
 // NodeMaintenanceStatus defines the observed state of NodeMaintenance
 type NodeMaintenanceStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
@@ -76,7 +86,7 @@ type NodeMaintenanceStatus struct {
 	PendingPods []string `json:"pendingPods,omitempty"`
 	// PendingPodsRefs is a list of refs of pending pods for eviction
 	//+operator-sdk:csv:customresourcedefinitions:type=status
-	PendingPodsRefs []corev1.ObjectReference `json:"pendingPodsRefs,omitempty"`
+	PendingPodsRefs []PodReference `json:"pendingPodsRefs,omitempty"`
 	// TotalPods is the total number of all pods on the node from the start
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	TotalPods int `json:"totalpods,omitempty"`

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -366,6 +366,7 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
+  replaces: node-maintenance-operator.v0.0.1
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: ""
-    createdAt: "2025-06-19T09:34:59Z"
+    createdAt: ""
     description: Node Maintenance Operator for cordoning and draining nodes.
     olm.skipRange: '>=0.12.0'
     operatorframework.io/suggested-namespace: openshift-workload-availability

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: ""
-    createdAt: ""
+    createdAt: "2025-06-19T09:34:59Z"
     description: Node Maintenance Operator for cordoning and draining nodes.
     olm.skipRange: '>=0.12.0'
     operatorframework.io/suggested-namespace: openshift-workload-availability
@@ -69,6 +69,9 @@ spec:
       - description: PendingPods is a list of pending pods for eviction
         displayName: Pending Pods
         path: pendingPods
+      - description: PendingPodsRefs is a list of refs of pending pods for eviction
+        displayName: Pending Pods Refs
+        path: pendingPodsRefs
       - description: Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
         displayName: Phase
         path: phase
@@ -363,7 +366,6 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
-  replaces: node-maintenance-operator.v0.0.1
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -82,66 +82,18 @@ spec:
                 description: PendingPodsRefs is a list of refs of pending pods for
                   eviction
                 items:
-                  description: |-
-                    ObjectReference contains enough information to let you inspect or modify the referred object.
-                    ---
-                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                        Those cannot be well described when embedded.
-                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                        and the version of the actual struct is irrelevant.
-                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
                   properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: |-
-                        If referring to a piece of an object instead of an entire object, this string
-                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within a pod, this would take on a value like:
-                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]" (container with
-                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                        referencing a part of an object.
-                        TODO: this design is not final and this field is subject to change in the future.
-                      type: string
-                    kind:
-                      description: |-
-                        Kind of the referent.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                      type: string
                     name:
                       description: |-
-                        Name of the referent.
+                        Name of the referent pod.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       description: |-
-                        Namespace of the referent.
+                        Namespace of the referent pod.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
-                    resourceVersion:
-                      description: |-
-                        Specific resourceVersion to which this reference is made, if any.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                      type: string
-                    uid:
-                      description: |-
-                        UID of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                      type: string
                   type: object
-                  x-kubernetes-map-type: atomic
                 type: array
               phase:
                 description: Phase is the represtation of the maintenance progress

--- a/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/bundle/manifests/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -78,6 +78,71 @@ spec:
                 items:
                   type: string
                 type: array
+              pendingPodsRefs:
+                description: PendingPodsRefs is a list of refs of pending pods for
+                  eviction
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               phase:
                 description: Phase is the represtation of the maintenance progress
                   (Running,Succeeded,Failed)

--- a/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -76,6 +76,71 @@ spec:
                 items:
                   type: string
                 type: array
+              pendingPodsRefs:
+                description: PendingPodsRefs is a list of refs of pending pods for
+                  eviction
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               phase:
                 description: Phase is the represtation of the maintenance progress
                   (Running,Succeeded,Failed)

--- a/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
+++ b/config/crd/bases/nodemaintenance.medik8s.io_nodemaintenances.yaml
@@ -80,66 +80,18 @@ spec:
                 description: PendingPodsRefs is a list of refs of pending pods for
                   eviction
                 items:
-                  description: |-
-                    ObjectReference contains enough information to let you inspect or modify the referred object.
-                    ---
-                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                        Those cannot be well described when embedded.
-                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                        and the version of the actual struct is irrelevant.
-                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
                   properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: |-
-                        If referring to a piece of an object instead of an entire object, this string
-                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within a pod, this would take on a value like:
-                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]" (container with
-                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                        referencing a part of an object.
-                        TODO: this design is not final and this field is subject to change in the future.
-                      type: string
-                    kind:
-                      description: |-
-                        Kind of the referent.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                      type: string
                     name:
                       description: |-
-                        Name of the referent.
+                        Name of the referent pod.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
                       description: |-
-                        Namespace of the referent.
+                        Namespace of the referent pod.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
-                    resourceVersion:
-                      description: |-
-                        Specific resourceVersion to which this reference is made, if any.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                      type: string
-                    uid:
-                      description: |-
-                        UID of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                      type: string
                   type: object
-                  x-kubernetes-map-type: atomic
                 type: array
               phase:
                 description: Phase is the represtation of the maintenance progress

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -54,6 +54,9 @@ spec:
       - description: PendingPods is a list of pending pods for eviction
         displayName: Pending Pods
         path: pendingPods
+      - description: PendingPodsRefs is a list of refs of pending pods for eviction
+        displayName: Pending Pods Refs
+        path: pendingPodsRefs
       - description: Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
         displayName: Phase
         path: phase

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -245,6 +245,7 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	nm.Status.Phase = v1beta1.MaintenanceSucceeded
 	nm.Status.DrainProgress = 100
 	nm.Status.PendingPods = nil
+	nm.Status.PendingPodsRefs = nil
 	err = r.Client.Status().Update(ctx, nm)
 	if err != nil {
 		r.logger.Error(err, "Failed to update NodeMaintenance with \"Succeeded\" status")

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -432,6 +432,7 @@ func initMaintenanceStatus(ctx context.Context, nm *v1beta1.NodeMaintenance, dra
 		}
 		if pendingList != nil {
 			nm.Status.PendingPods = GetPodNameList(pendingList.Pods())
+			nm.Status.PendingPodsRefs = GetPodRefList(pendingList.Pods())
 		}
 		nm.Status.EvictionPods = len(nm.Status.PendingPods)
 
@@ -457,6 +458,7 @@ func (r *NodeMaintenanceReconciler) onReconcileErrorWithRequeue(ctx context.Cont
 		pendingList, _ := drainer.GetPodsForDeletion(nm.Spec.NodeName)
 		if pendingList != nil {
 			nm.Status.PendingPods = GetPodNameList(pendingList.Pods())
+			nm.Status.PendingPodsRefs = GetPodRefList(pendingList.Pods())
 			if nm.Status.EvictionPods != 0 {
 				nm.Status.DrainProgress = (nm.Status.EvictionPods - len(nm.Status.PendingPods)) * 100 / nm.Status.EvictionPods
 			}

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Node Maintenance", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(nm.Status.Phase).To(Equal(v1beta1.MaintenanceRunning))
 					Expect(len(nm.Status.PendingPods)).To(Equal(2))
+					Expect(len(nm.Status.PendingPodsRefs)).To(Equal(2))
 					Expect(nm.Status.EvictionPods).To(Equal(2))
 					Expect(nm.Status.TotalPods).To(Equal(2))
 					Expect(nm.Status.DrainProgress).To(Equal(0))
@@ -109,6 +110,7 @@ var _ = Describe("Node Maintenance", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(nmCopy.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
 					Expect(len(nmCopy.Status.PendingPods)).To(Equal(0))
+					Expect(len(nmCopy.Status.PendingPodsRefs)).To(Equal(0))
 					Expect(nmCopy.Status.EvictionPods).To(Equal(0))
 					Expect(nmCopy.Status.TotalPods).To(Equal(0))
 					Expect(nmCopy.Status.DrainProgress).To(Equal(0))
@@ -201,6 +203,7 @@ var _ = Describe("Node Maintenance", func() {
 
 				Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceSucceeded))
 				Expect(len(maintenance.Status.PendingPods)).To(Equal(0))
+				Expect(len(maintenance.Status.PendingPodsRefs)).To(Equal(0))
 				Expect(maintenance.Status.EvictionPods).To(Equal(2))
 				Expect(maintenance.Status.TotalPods).To(Equal(2))
 				Expect(maintenance.Status.DrainProgress).To(Equal(100))
@@ -244,6 +247,7 @@ var _ = Describe("Node Maintenance", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
 
 				Expect(len(maintenance.Status.PendingPods)).To(Equal(0))
+				Expect(len(maintenance.Status.PendingPodsRefs)).To(Equal(0))
 				Expect(maintenance.Status.EvictionPods).To(Equal(0))
 				Expect(maintenance.Status.TotalPods).To(Equal(0))
 				Expect(maintenance.Status.DrainProgress).To(Equal(0))

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/medik8s/node-maintenance-operator/api/v1beta1"
 )
 
 // ContainsString checks if the string array contains the given string.
@@ -34,14 +36,11 @@ func GetPodNameList(pods []corev1.Pod) (result []string) {
 }
 
 // GetPodRefList returns a list of pod references.
-func GetPodRefList(pods []corev1.Pod) (result []corev1.ObjectReference) {
+func GetPodRefList(pods []corev1.Pod) (result []v1beta1.PodReference) {
 	for _, pod := range pods {
-		result = append(result, corev1.ObjectReference{
-			Kind:       pod.Kind,
-			APIVersion: pod.APIVersion,
-			Namespace:  pod.Namespace,
-			Name:       pod.Name,
-			UID:        pod.UID,
+		result = append(result, v1beta1.PodReference{
+			Namespace: pod.Namespace,
+			Name:      pod.Name,
 		})
 	}
 	return result

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ContainsString checks if the string array contains the given string.
@@ -26,10 +25,25 @@ func RemoveString(slice []string, s string) (result []string) {
 	return result
 }
 
-// GetPodNameList returns a list of pod identifiers in the form "namespace/name".
+// GetPodNameList returns a list of pod names from a pod list
 func GetPodNameList(pods []corev1.Pod) (result []string) {
 	for _, pod := range pods {
-		result = append(result, client.ObjectKeyFromObject(&pod).String())
+		result = append(result, pod.Name)
 	}
 	return result
+}
+
+// GetPodRefList returns a list of pod references.
+func GetPodRefList(pods []corev1.Pod) (result []corev1.ObjectReference) {
+	for _, pod := range pods {
+		result = append(result, corev1.ObjectReference{
+			Kind:       pod.Kind,
+			APIVersion: pod.APIVersion,
+			Namespace:  pod.Namespace,
+			Name:       pod.Name,
+			UID:        pod.UID,
+		})
+	}
+	return result
+
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,6 +1,9 @@
 package controllers
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // ContainsString checks if the string array contains the given string.
 func ContainsString(slice []string, s string) bool {
@@ -23,10 +26,10 @@ func RemoveString(slice []string, s string) (result []string) {
 	return result
 }
 
-// GetPodNameList returns a list of pod names from a pod list
+// GetPodNameList returns a list of pod identifiers in the form "namespace/name".
 func GetPodNameList(pods []corev1.Pod) (result []string) {
 	for _, pod := range pods {
-		result = append(result, pod.ObjectMeta.Name)
+		result = append(result, client.ObjectKeyFromObject(&pod).String())
 	}
 	return result
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -30,7 +30,7 @@ func RemoveString(slice []string, s string) (result []string) {
 // GetPodNameList returns a list of pod names from a pod list
 func GetPodNameList(pods []corev1.Pod) (result []string) {
 	for _, pod := range pods {
-		result = append(result, pod.Name)
+		result = append(result, pod.ObjectMeta.Name)
 	}
 	return result
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR

More observable status for NodeMaintenance resource. We can get full pod name from new version of `PendingPods`.

#### Changes made


Changed filling of the `NodeMaintenance.status.pendingPods` without significant changes to CRD struct

from:
```
status:
  pendingPods:
  - name
```

to: 

```
status:
  pendingPods:
  - namespace/name
```

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed pod references to the Node Maintenance status for better tracking of pods pending eviction.
  - Enhanced status descriptors to include pod reference information for improved visibility in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->