### PR TITLE
Configurable MaxConcurrentReconciles

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -91,12 +91,13 @@ var _ = BeforeSuite(func() {
 	fakeRecorder = record.NewFakeRecorder(20)
 	// Create a ReconcileNodeMaintenance object with the scheme and fake client
 	r = &NodeMaintenanceReconciler{
-		Client:       k8sClient,
-		Scheme:       scheme.Scheme,
-		MgrConfig:    cfg,
-		LeaseManager: &mockLeaseManager{mockManager},
-		Recorder:     fakeRecorder,
-		logger:       ctrl.Log.WithName("unit test"),
+		Client:                  k8sClient,
+		Scheme:                  scheme.Scheme,
+		MgrConfig:               cfg,
+		LeaseManager:            &mockLeaseManager{mockManager},
+		Recorder:                fakeRecorder,
+		logger:                  ctrl.Log.WithName("unit test"),
+		MaxConcurrentReconciles: 1,
 	}
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 	drainer, err = createDrainer(ctx, cfg)

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	commonLabels "github.com/medik8s/common/pkg/labels"
 	"github.com/medik8s/common/pkg/lease"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,11 +68,16 @@ type NodeMaintenanceReconciler struct {
 	LeaseManager lease.Manager
 	Recorder     record.EventRecorder
 	logger       logr.Logger
+
+	MaxConcurrentReconciles int
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeMaintenanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+		}).
 		For(&v1beta1.NodeMaintenance{}).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ const (
 	WebhookCertDir  = "/apiserver.local.config/certificates"
 	WebhookCertName = "apiserver.crt"
 	WebhookKeyName  = "apiserver.key"
-	operatorName = "NodeMaintenance"
+	operatorName    = "NodeMaintenance"
 )
 
 var (
@@ -69,16 +69,18 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr, probeAddr string
+		metricsAddr, probeAddr            string
 		enableLeaderElection, enableHTTP2 bool
-		webhookOpts          webhook.Options
-	) 
+		webhookOpts                       webhook.Options
+		maxConcurrentReconciles           int
+	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false, "If HTTP/2 should be enabled for the metrics and webhook servers.")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "The number of max concurrent reconciles")
 
 	opts := zap.Options{
 		Development: true,
@@ -94,7 +96,7 @@ func main() {
 	configureWebhookOpts(&webhookOpts, enableHTTP2)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme: scheme,
+		Scheme:                 scheme,
 		WebhookServer:          webhook.NewServer(webhookOpts),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
@@ -105,31 +107,30 @@ func main() {
 		os.Exit(1)
 	}
 
-
 	cl := mgr.GetClient()
 	leaseManagerInitializer := &leaseManagerInitializer{cl: cl}
 	if err := mgr.Add(leaseManagerInitializer); err != nil {
 		setupLog.Error(err, "unable to set up lease Manager", "lease", operatorName)
 		os.Exit(1)
 	}
-	
-	openshiftCheck,err := utils.NewOpenshiftValidator(mgr.GetConfig())
+
+	openshiftCheck, err := utils.NewOpenshiftValidator(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "failed to check if we run on Openshift")
 		os.Exit(1)
 	}
 	isOpenShift := openshiftCheck.IsOpenshiftSupported()
-	if isOpenShift{
+	if isOpenShift {
 		setupLog.Info("NMO was installed on Openshift cluster")
 	}
-	
 
 	if err = (&controllers.NodeMaintenanceReconciler{
-		Client:       cl,
-		Scheme:       mgr.GetScheme(),
-		MgrConfig:    mgr.GetConfig(),
-		LeaseManager: leaseManagerInitializer,
-		Recorder: mgr.GetEventRecorderFor(operatorName),
+		Client:                  cl,
+		Scheme:                  mgr.GetScheme(),
+		MgrConfig:               mgr.GetConfig(),
+		LeaseManager:            leaseManagerInitializer,
+		Recorder:                mgr.GetEventRecorderFor(operatorName),
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", operatorName)
 		os.Exit(1)


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR

Default value for controller-manager for MaxConcurrentReconciles is 1.
If we are going to start n parallel `NodeMaintenance`s at the same time. We'll handle last one after `n * d` time. Where d is duration of reconcile. 
[In current model the longest reconcile is more then 30s](https://github.com/medik8s/node-maintenance-operator/blob/main/controllers/nodemaintenance_controller.go#L59)

That means - if we are starting ~50 parallel NodeMaintenances and each of them are failed to finish immediately (some blocking PDB exists) we we'll came up with the last one only after ~30mins.

#### Changes made

Added cli arg to override `MaxConcurrentReconciles`


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to control the maximum number of concurrent reconciliation processes for node maintenance.
- **Improvements**
  - Enhanced configurability of node maintenance operations by allowing users to set concurrency limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->