### PR TITLE
Small Fixes to Release Job, Push Pipeline and catalog-build

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 permissions:
   contents: write

--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ container-build: check ## Build containers
 	make docker-build bundle-build
 
 .PHONY: bundle-build-community
-bundle-build-community: bundle-community ## Run bundle community changes in CSV, and then build the bundle image.
+bundle-build-community: bundle-community-k8s ## Run bundle community changes in CSV, and then build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: container-build-community

--- a/Makefile
+++ b/Makefile
@@ -457,8 +457,8 @@ build-tools: ## Download & build all the tools locally if necessary.
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a file-based catalog image.
-	# Remove the catalog directory and Dockerfile
-	-rm -r ${CATALOG_DIR} ${CATALOG_DOCKERFILE}
+	# Remove the catalog directory and Dockerfile if they exist
+	-rm -rf ${CATALOG_DIR} ${CATALOG_DOCKERFILE}
 	@mkdir -p ${CATALOG_DIR}
 	$(OPM) generate dockerfile ${CATALOG_DIR}
 	$(OPM) init ${OPERATOR_NAME} \
@@ -472,7 +472,7 @@ catalog-build: opm ## Build a file-based catalog image.
 	$(OPM) validate ${CATALOG_DIR}
 	docker build . -f ${CATALOG_DOCKERFILE} -t ${CATALOG_IMG}
 	# Clean up the catalog directory and Dockerfile
-	rm -r ${CATALOG_DIR} ${CATALOG_DOCKERFILE}
+	-rm -rf ${CATALOG_DIR} ${CATALOG_DOCKERFILE}
 
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
- [Release Job](https://github.com/medik8s/node-maintenance-operator/actions/workflows/release.yaml) was building a bundle image without updating the bundle's image version by not running the `bundle` target. See the  following [error](https://github.com/medik8s/node-maintenance-operator/actions/runs/19434066334/job/55600158139):
```
.
.
.
v0.19.0: digest: sha256:aac8265be2e3b4c5639daddc619995bfc56da4e07be01cf88d65e6508453c953 size: 939
make[1]: Leaving directory '/home/runner/work/node-maintenance-operator/node-maintenance-operator'
# Remove the catalog directory and Dockerfile
rm -r catalog catalog.Dockerfile
rm: cannot remove 'catalog': No such file or directory
rm: cannot remove 'catalog.Dockerfile': No such file or directory
make: [Makefile:461: catalog-build] Error 1 (ignored)
/home/runner/work/node-maintenance-operator/node-maintenance-operator/bin/opm/v1.60.0/opm generate dockerfile catalog
/home/runner/work/node-maintenance-operator/node-maintenance-operator/bin/opm/v1.60.0/opm init node-maintenance-operator \
	--default-channel=stable \
	--description=./README.md \
	--icon="./config/assets/nmo_blue_icon.png" \
	--output yaml \
	> catalog/index.yaml
/home/runner/work/node-maintenance-operator/node-maintenance-operator/bin/opm/v1.60.0/opm render quay.io/medik8s/node-maintenance-operator-bundle:v0.19.0 --output yaml >> catalog/index.yaml
make add_channel_entry_for_the_bundle
make[1]: Entering directory '/home/runner/work/node-maintenance-operator/node-maintenance-operator'
make[1]: Leaving directory '/home/runner/work/node-maintenance-operator/node-maintenance-operator'
/home/runner/work/node-maintenance-operator/node-maintenance-operator/bin/opm/v1.60.0/opm validate catalog
time="2025-11-17T15:06:44Z" level=fatal msg="package \"node-maintenance-operator\", bundle \"node-maintenance-operator.v0.0.1\" not found in any channel entries"
make: *** [Makefile:467: catalog-build] Error 1
```

In addition, this fix should help with https://github.com/openshift/release/pull/71745#issuecomment-3580945359

- Skip deletion of catalog files and errors when running the `catalog-build` target.
```
# Remove the catalog directory and Dockerfile
rm -r catalog catalog.Dockerfile
rm: cannot remove 'catalog': No such file or directory
rm: cannot remove 'catalog.Dockerfile': No such file or directory
make[1]: [Makefile:482: catalog-build] Error 1 (ignored)
```
- Stop updating the `latest` tag when you push `v*` tags 
#### Changes made
<!-- Outline the specific changes made in this merge request. -->
- Modify the makefile target by calling `bundle-community-k8s` instead of `bundle-community` for the `bundle-build-community` target. 
**Workaround**: Use an older pipeline that works (e.g., from `v0.18.0`), instead of using a pipeline from `main` or a related release-branch.
- Modify the `catalog-build` target with `-rm -rf` to skip deletion errors
- The pipeline was running tests, and trying to push operator, bundle, and catalog images with tag 'latest' when we push a git tag upstream.

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build scripts to perform safer cleanup and adjusted the prerequisite step for community bundle image builds.
* **CI**
  * Updated post-submit workflow to stop triggering on tag pushes, narrowing automated runs to branch pushes only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->