### PR TITLE
NMO Doesn't Increment ErrorOnLeaseCount to Stop Maintenance

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 		Client:       k8sClient,
 		Scheme:       scheme.Scheme,
 		MgrConfig:    cfg,
-		LeaseManager: &mockLeaseManager{mockManager},
+		LeaseManager: &mockLeaseManager{Manager: mockManager},
 		Recorder:     fakeRecorder,
 		logger:       ctrl.Log.WithName("unit test"),
 	}

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -187,9 +187,10 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	setOwnerRefToNode(nm, node, r.logger)
-
-	updateOwnedLeaseFailed, err := r.obtainLease(ctx, node)
-	if err != nil && updateOwnedLeaseFailed {
+	var alreadyHeldErr lease.AlreadyHeldError
+	err = r.obtainLease(ctx, node)
+	if err != nil && errors.As(err, &alreadyHeldErr) {
+		r.logger.Info("lease is held by another entity, incrementing error on lease count", "error", err)
 		nm.Status.ErrorOnLeaseCount += 1
 		if nm.Status.ErrorOnLeaseCount > maxAllowedErrorToUpdateOwnedLease {
 			r.logger.Info("can't extend owned lease. uncordon for now")
@@ -206,9 +207,11 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to extend lease owned by us : %v errorOnLeaseCount %d", err, nm.Status.ErrorOnLeaseCount))
 	}
 	if err != nil {
+		r.logger.Error(err, "failed to request lease")
 		nm.Status.ErrorOnLeaseCount = 0
 		return r.onReconcileError(ctx, nm, drainer, err)
 	} else {
+		r.logger.Info("lease obtained successfully")
 		if nm.Status.Phase != v1beta1.MaintenanceRunning || nm.Status.ErrorOnLeaseCount != 0 {
 			nm.Status.Phase = v1beta1.MaintenanceRunning
 			// Another chance to evict pods - clear ErrorOnLeaseCount and try again to put the node under maintenance
@@ -336,21 +339,9 @@ func setOwnerRefToNode(nm *v1beta1.NodeMaintenance, node *corev1.Node, log logr.
 	nm.ObjectMeta.SetOwnerReferences(append(nm.ObjectMeta.GetOwnerReferences(), ref))
 }
 
-func (r *NodeMaintenanceReconciler) obtainLease(ctx context.Context, node *corev1.Node) (bool, error) {
-	r.logger.Info("Lease object supported, obtaining lease")
-	err := r.LeaseManager.RequestLease(ctx, node, LeaseDuration)
-
-	if err != nil {
-		var alreadyHeldErr lease.AlreadyHeldError
-		if errors.As(err, &alreadyHeldErr) {
-			// We don't own the lease and it could be NHC
-			return true, err
-		}
-		r.logger.Error(err, "failed to create or get existing lease")
-		return false, err
-	}
-
-	return true, nil
+func (r *NodeMaintenanceReconciler) obtainLease(ctx context.Context, node *corev1.Node) error {
+	r.logger.Info("Trying to obtain lease")
+	return r.LeaseManager.RequestLease(ctx, node, LeaseDuration)
 }
 
 func addExcludeRemediationLabel(ctx context.Context, node *corev1.Node, r client.Client, log logr.Logger) error {
@@ -395,7 +386,14 @@ func (r *NodeMaintenanceReconciler) stopNodeMaintenanceImp(ctx context.Context, 
 	// stop maintenance - remove the added taints and uncordon the node
 	utils.NormalEvent(r.Recorder, node, utils.EventReasonUncordonNode, utils.EventMessageUncordonNode)
 	if err := r.LeaseManager.InvalidateLease(ctx, node); err != nil {
-		return err
+		var alreadyHeldErr lease.AlreadyHeldError
+		if errors.As(err, &alreadyHeldErr) {
+			// The lease is held by another entity (e.g. NHC), we don't own it
+			// so there is nothing to invalidate — proceed with cleanup
+			r.logger.Info("lease is held by another entity, skipping invalidation", "error", err)
+		} else {
+			return err
+		}
 	}
 	return removeExcludeRemediationLabel(ctx, node, r.Client, r.logger)
 }

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -404,7 +404,12 @@ func (r *NodeMaintenanceReconciler) stopNodeMaintenanceOnDeletion(ctx context.Co
 		// if CR is gathered as result of garbage collection: the node may have been deleted, but the CR has not yet been deleted, still we must clean up the lease!
 		if apiErrors.IsNotFound(err) {
 			if err := r.LeaseManager.InvalidateLease(ctx, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}); err != nil {
-				return err
+				var alreadyHeldErr lease.AlreadyHeldError
+				if errors.As(err, &alreadyHeldErr) {
+					r.logger.Info("lease is held by another entity, skipping invalidation during deletion cleanup", "error", err)
+				} else {
+					return err
+				}
 			}
 			return nil
 		}

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -187,28 +187,39 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	setOwnerRefToNode(nm, node, r.logger)
-	var alreadyHeldErr lease.AlreadyHeldError
-	err = r.obtainLease(ctx, node)
-	if err != nil && errors.As(err, &alreadyHeldErr) {
-		r.logger.Info("lease is held by another entity, incrementing error on lease count", "error", err)
-		nm.Status.ErrorOnLeaseCount += 1
-		if nm.Status.ErrorOnLeaseCount > maxAllowedErrorToUpdateOwnedLease {
-			r.logger.Info("can't extend owned lease. uncordon for now")
+	// if we failed to extend a lease that used to be owned by us or there are other errors, then we need to uncordon the node and fail the maintenance
+	if nm.Status.ErrorOnLeaseCount > maxAllowedErrorToUpdateOwnedLease {
+		r.logger.Info("lease could not be extended, failing maintenance", "errorOnLeaseCount", nm.Status.ErrorOnLeaseCount)
 
-			// Uncordon the node
-			err = r.stopNodeMaintenanceImp(ctx, drainer, node)
-			if err != nil {
-				return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to uncordon upon failure to obtain owned lease : %v ", err))
-			}
-			// maintenance has failed - node was uncordon and under maintenance mode
-			utils.WarningEvent(r.Recorder, nm, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
-			nm.Status.Phase = v1beta1.MaintenanceFailed
+		err = r.stopNodeMaintenanceImp(ctx, drainer, node)
+		if err != nil {
+			return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to uncordon upon failure to obtain owned lease: %v", err))
 		}
-		return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to extend lease owned by us : %v errorOnLeaseCount %d", err, nm.Status.ErrorOnLeaseCount))
+		utils.WarningEvent(r.Recorder, nm, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+		nm.Status.Phase = v1beta1.MaintenanceFailed
+		nm.Status.LastError = fmt.Sprintf("maintenance failed: lease could not be extended after %d attempts", nm.Status.ErrorOnLeaseCount)
+		setLastUpdate(nm)
+		if updateErr := r.Client.Status().Update(ctx, nm); updateErr != nil {
+			r.logger.Error(updateErr, "Failed to update NodeMaintenance status")
+			return ctrl.Result{}, updateErr
+		}
+		return ctrl.Result{}, nil
 	}
+	err = r.LeaseManager.RequestLease(ctx, node, LeaseDuration)
 	if err != nil {
-		r.logger.Error(err, "failed to request lease")
-		nm.Status.ErrorOnLeaseCount = 0
+		var alreadyHeldErr lease.AlreadyHeldError
+		if errors.As(err, &alreadyHeldErr) {
+			r.logger.Error(err, "lease is held by another entity")
+			if nm.Status.DrainProgress > 0 {
+				// if we are already in the middle of draining, and we failed to extend a lease that used to be owned by us
+				// then we need to increment the error on lease count and return an error
+				nm.Status.ErrorOnLeaseCount += 1
+				return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to extend a lease that used to be owned by us, due toncrementing error on lease count : %v, new errorOnLeaseCount: %d", err, nm.Status.ErrorOnLeaseCount))
+			}
+			return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to obtain a lease that is not owned by us : %v errorOnLeaseCount %d", err, nm.Status.ErrorOnLeaseCount))
+		}
+		r.logger.Error(err, "failed to request lease, and incrementing error on lease count", "errorOnLeaseCount", nm.Status.ErrorOnLeaseCount)
+		nm.Status.ErrorOnLeaseCount += 1
 		return r.onReconcileError(ctx, nm, drainer, err)
 	} else {
 		r.logger.Info("lease obtained successfully")
@@ -216,7 +227,6 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			nm.Status.Phase = v1beta1.MaintenanceRunning
 			// Another chance to evict pods - clear ErrorOnLeaseCount and try again to put the node under maintenance
 			nm.Status.ErrorOnLeaseCount = 0
-
 		}
 	}
 
@@ -339,11 +349,6 @@ func setOwnerRefToNode(nm *v1beta1.NodeMaintenance, node *corev1.Node, log logr.
 	nm.ObjectMeta.SetOwnerReferences(append(nm.ObjectMeta.GetOwnerReferences(), ref))
 }
 
-func (r *NodeMaintenanceReconciler) obtainLease(ctx context.Context, node *corev1.Node) error {
-	r.logger.Info("Trying to obtain lease")
-	return r.LeaseManager.RequestLease(ctx, node, LeaseDuration)
-}
-
 func addExcludeRemediationLabel(ctx context.Context, node *corev1.Node, r client.Client, log logr.Logger) error {
 	if node.Labels[commonLabels.ExcludeFromRemediation] != "true" {
 		patch := client.MergeFrom(node.DeepCopy())
@@ -390,7 +395,7 @@ func (r *NodeMaintenanceReconciler) stopNodeMaintenanceImp(ctx context.Context, 
 		if errors.As(err, &alreadyHeldErr) {
 			// The lease is held by another entity (e.g. NHC), we don't own it
 			// so there is nothing to invalidate — proceed with cleanup
-			r.logger.Info("lease is held by another entity, skipping invalidation", "error", err)
+			r.logger.Info("lease is held by another entity, then skipping invalidation when stopping node maintenance", "error", err)
 		} else {
 			return err
 		}

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -214,20 +214,19 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				// if we are already in the middle of draining, and we failed to extend a lease that used to be owned by us
 				// then we need to increment the error on lease count and return an error
 				nm.Status.ErrorOnLeaseCount += 1
-				return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to extend a lease that used to be owned by us, due toncrementing error on lease count : %v, new errorOnLeaseCount: %d", err, nm.Status.ErrorOnLeaseCount))
+				return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to extend a lease that used to be owned by us, incrementing error on lease count: %v, errorOnLeaseCount: %d", err, nm.Status.ErrorOnLeaseCount))
 			}
 			return r.onReconcileError(ctx, nm, drainer, fmt.Errorf("failed to obtain a lease that is not owned by us : %v errorOnLeaseCount %d", err, nm.Status.ErrorOnLeaseCount))
 		}
 		r.logger.Error(err, "failed to request lease, and incrementing error on lease count", "errorOnLeaseCount", nm.Status.ErrorOnLeaseCount)
 		nm.Status.ErrorOnLeaseCount += 1
 		return r.onReconcileError(ctx, nm, drainer, err)
-	} else {
-		r.logger.Info("lease obtained successfully")
-		if nm.Status.Phase != v1beta1.MaintenanceRunning || nm.Status.ErrorOnLeaseCount != 0 {
-			nm.Status.Phase = v1beta1.MaintenanceRunning
-			// Another chance to evict pods - clear ErrorOnLeaseCount and try again to put the node under maintenance
-			nm.Status.ErrorOnLeaseCount = 0
-		}
+	}
+	r.logger.Info("lease obtained successfully")
+	if nm.Status.Phase != v1beta1.MaintenanceRunning || nm.Status.ErrorOnLeaseCount != 0 {
+		nm.Status.Phase = v1beta1.MaintenanceRunning
+		// Another chance to evict pods - clear ErrorOnLeaseCount and try again to put the node under maintenance
+		nm.Status.ErrorOnLeaseCount = 0
 	}
 
 	if err := addExcludeRemediationLabel(ctx, node, r.Client, r.logger); err != nil {

--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -340,11 +341,16 @@ func (r *NodeMaintenanceReconciler) obtainLease(ctx context.Context, node *corev
 	err := r.LeaseManager.RequestLease(ctx, node, LeaseDuration)
 
 	if err != nil {
+		var alreadyHeldErr lease.AlreadyHeldError
+		if errors.As(err, &alreadyHeldErr) {
+			// We don't own the lease and it could be NHC
+			return true, err
+		}
 		r.logger.Error(err, "failed to create or get existing lease")
 		return false, err
 	}
 
-	return false, nil
+	return true, nil
 }
 
 func addExcludeRemediationLabel(ctx context.Context, node *corev1.Node, r client.Client, log logr.Logger) error {

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -315,7 +315,10 @@ var _ = Describe("Node Maintenance", func() {
 			})
 			It("should wait for lease to be released and succeed maintenance after lease is released", func() {
 				By("Waiting for NMO to fail from lease contention, then recover after lease is released")
-				verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+				Eventually(func() error {
+					verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+					return nil
+				}, "5s", "200ms").Should(Succeed())
 
 				maintenance := &v1beta1.NodeMaintenance{}
 				Eventually(func(g Gomega) {

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -260,6 +260,81 @@ var _ = Describe("Node Maintenance", func() {
 				verifyNoEvent(corev1.EventTypeNormal, utils.EventReasonSucceedMaintenance, utils.EventMessageSucceedMaintenance)
 			})
 		})
+		When("lease is already held by another entity", func() {
+			BeforeEach(func() {
+				originalLeaseManager := r.LeaseManager
+				r.LeaseManager = &mockLeaseManager{
+					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
+					requestLeaseErr:    lease.AlreadyHeldError{},
+					invalidateLeaseErr: lease.AlreadyHeldError{},
+				}
+				DeferCleanup(func() {
+					r.LeaseManager = originalLeaseManager
+				})
+
+				nm = getTestNM("node-maintenance-lease-held", taintedNodeName)
+				Expect(k8sClient.Create(ctx, nm)).To(Succeed())
+				DeferCleanup(k8sClient.Delete, ctx, nm)
+			})
+			It("should increment ErrorOnLeaseCount and fail maintenance after exceeding max retries", func() {
+				By("Waiting for ErrorOnLeaseCount to exceed the threshold and phase to become Failed")
+				maintenance := &v1beta1.NodeMaintenance{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(BeNumerically(">", maxAllowedErrorToUpdateOwnedLease))
+					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
+				}, "2s", "500ms").Should(Succeed())
+
+				By("Verifying maintenance failed event was emitted")
+				verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+
+				By("Verifying LastError mentions lease contention")
+				Expect(maintenance.Status.LastError).To(ContainSubstring("failed to extend lease owned by us"))
+			})
+		})
+		When("lease is held then released by another entity", func() {
+			BeforeEach(func() {
+				originalLeaseManager := r.LeaseManager
+				// The mock returns AlreadyHeldError for exactly (maxAllowedErrorToUpdateOwnedLease + 2)
+				// RequestLease calls, then returns nil — simulating NHC releasing the lease.
+				// This limits rate limiter failures so the recovery reconcile happens quickly
+				// (backoff stays under 1s), avoiding the 40s+ backoff from unlimited failures.
+				r.LeaseManager = &mockLeaseManager{
+					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
+					requestLeaseErr:    lease.AlreadyHeldError{},
+					invalidateLeaseErr: lease.AlreadyHeldError{},
+					maxRequestFailures: maxAllowedErrorToUpdateOwnedLease + 2,
+				}
+				DeferCleanup(func() {
+					r.LeaseManager = originalLeaseManager
+				})
+
+				nm = getTestNM("node-maintenance-lease-released", taintedNodeName)
+				Expect(k8sClient.Create(ctx, nm)).To(Succeed())
+				DeferCleanup(k8sClient.Delete, ctx, nm)
+			})
+			It("should wait for lease to be released and succeed maintenance after lease is released", func() {
+				By("Waiting for NMO to fail from lease contention, then recover after lease is released")
+				verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+
+				maintenance := &v1beta1.NodeMaintenance{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceSucceeded))
+					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(Equal(0))
+					g.Expect(maintenance.Status.DrainProgress).To(Equal(100))
+				}, "5s", "500ms").Should(Succeed())
+
+				By("Verifying node was cordoned with proper taints")
+				node := &corev1.Node{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, node)).To(Succeed())
+				Expect(node.Spec.Unschedulable).To(BeTrue())
+				Expect(isTaintExist(node, medik8sDrainTaint.Key, corev1.TaintEffectNoSchedule)).To(BeTrue())
+				Expect(isTaintExist(node, nodeUnschedulableTaint.Key, corev1.TaintEffectNoSchedule)).To(BeTrue())
+
+				verifyEvent(corev1.EventTypeNormal, utils.EventReasonSucceedMaintenance, utils.EventMessageSucceedMaintenance)
+			})
+		})
 	})
 })
 
@@ -413,8 +488,29 @@ func clearEvents() {
 
 type mockLeaseManager struct {
 	lease.Manager
+	requestLeaseErr error
+	// maxRequestFailures limits how many times RequestLease returns requestLeaseErr.
+	// 0 means unlimited (fail forever). When requestFailCount reaches maxRequestFailures,
+	// RequestLease returns nil — simulating the lease being released.
+	maxRequestFailures int
+	requestFailCount   int
+
+	invalidateLeaseErr error
 }
 
 func (mock *mockLeaseManager) RequestLease(_ context.Context, _ client.Object, _ time.Duration) error {
+	if mock.requestLeaseErr != nil {
+		if mock.maxRequestFailures <= 0 || mock.requestFailCount < mock.maxRequestFailures {
+			mock.requestFailCount++
+			return mock.requestLeaseErr
+		}
+	}
 	return nil
+}
+
+func (mock *mockLeaseManager) InvalidateLease(ctx context.Context, obj client.Object) error {
+	if mock.invalidateLeaseErr != nil {
+		return mock.invalidateLeaseErr
+	}
+	return mock.Manager.InvalidateLease(ctx, obj)
 }

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -29,6 +29,9 @@ const (
 	dummyLabelKey   = "dummyLabel"
 	dummyLabelValue = "true"
 	testNamespace   = "test-namespace"
+
+	defaultTimeout  = 2 * time.Second
+	defaultInterval = 500 * time.Millisecond
 )
 
 var testLog = ctrl.Log.WithName("nmo-controllers-unit-test")
@@ -264,9 +267,8 @@ var _ = Describe("Node Maintenance", func() {
 			BeforeEach(func() {
 				originalLeaseManager := r.LeaseManager
 				r.LeaseManager = &mockLeaseManager{
-					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
-					requestLeaseErr:    lease.AlreadyHeldError{},
-					invalidateLeaseErr: lease.AlreadyHeldError{},
+					Manager:         originalLeaseManager.(*mockLeaseManager).Manager,
+					requestLeaseErr: lease.AlreadyHeldError{},
 				}
 				DeferCleanup(func() {
 					r.LeaseManager = originalLeaseManager
@@ -282,7 +284,7 @@ var _ = Describe("Node Maintenance", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
 					g.Expect(maintenance.Status.LastError).To(ContainSubstring("failed to obtain a lease that is not owned by us"))
-				}, "2s", "500ms").Should(Succeed())
+				}, defaultTimeout, defaultInterval).Should(Succeed())
 
 				By("Verifying ErrorOnLeaseCount stays at 0 since DrainProgress is 0")
 				Expect(maintenance.Status.ErrorOnLeaseCount).To(Equal(0))
@@ -303,7 +305,6 @@ var _ = Describe("Node Maintenance", func() {
 				r.LeaseManager = &mockLeaseManager{
 					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
 					requestLeaseErr:    lease.AlreadyHeldError{},
-					invalidateLeaseErr: lease.AlreadyHeldError{},
 					maxRequestFailures: maxAllowedErrorToUpdateOwnedLease + 2,
 				}
 				DeferCleanup(func() {
@@ -315,14 +316,20 @@ var _ = Describe("Node Maintenance", func() {
 				DeferCleanup(k8sClient.Delete, ctx, nm)
 			})
 			It("should succeed maintenance directly after lease is released without entering Failed state", func() {
-				By("Waiting for NMO to acquire the lease and complete maintenance")
+				By("Confirming the lease was held by another entity")
 				maintenance := &v1beta1.NodeMaintenance{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.LastError).To(ContainSubstring("failed to obtain a lease that is not owned by us"))
+				}, defaultTimeout, defaultInterval).Should(Succeed())
+
+				By("Waiting for NMO to acquire the lease and complete maintenance")
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
 					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceSucceeded))
 					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(Equal(0))
 					g.Expect(maintenance.Status.DrainProgress).To(Equal(100))
-				}, "5s", "500ms").Should(Succeed())
+				}, defaultTimeout, defaultInterval).Should(Succeed())
 
 				By("Verifying node was cordoned with proper taints")
 				node := &corev1.Node{}
@@ -346,7 +353,6 @@ var _ = Describe("Node Maintenance", func() {
 				r.LeaseManager = &mockLeaseManager{
 					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
 					requestLeaseErr:    lease.AlreadyHeldError{},
-					invalidateLeaseErr: lease.AlreadyHeldError{},
 					failAfterSuccesses: 1,
 					maxRequestFailures: 2,
 				}
@@ -359,14 +365,20 @@ var _ = Describe("Node Maintenance", func() {
 				DeferCleanup(k8sClient.Delete, ctx, nm)
 			})
 			It("should suspend, recover the lease, and succeed maintenance", func() {
-				By("Waiting for NMO to recover the lease and complete maintenance")
+				By("Confirming the lease was lost during maintenance")
 				maintenance := &v1beta1.NodeMaintenance{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.LastError).To(ContainSubstring("failed to extend a lease that used to be owned by us"))
+				}, defaultTimeout, defaultInterval).Should(Succeed())
+
+				By("Waiting for NMO to recover the lease and complete maintenance")
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
 					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceSucceeded))
 					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(Equal(0))
 					g.Expect(maintenance.Status.DrainProgress).To(Equal(100))
-				}, "10s", "500ms").Should(Succeed())
+				}, defaultTimeout, defaultInterval).Should(Succeed())
 
 				By("Verifying no FailedMaintenance event was emitted")
 				verifyNoEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
@@ -383,7 +395,6 @@ var _ = Describe("Node Maintenance", func() {
 				r.LeaseManager = &mockLeaseManager{
 					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
 					requestLeaseErr:    lease.AlreadyHeldError{},
-					invalidateLeaseErr: lease.AlreadyHeldError{},
 					failAfterSuccesses: 1,
 				}
 				DeferCleanup(func() {
@@ -395,13 +406,14 @@ var _ = Describe("Node Maintenance", func() {
 				DeferCleanup(k8sClient.Delete, ctx, nm)
 			})
 			It("should fail maintenance when lease cannot be recovered", func() {
-				By("Waiting for ErrorOnLeaseCount to exceed the threshold and phase to become Failed")
+				By("Waiting for maintenance to start, lease errors to exceed the threshold, and phase to become Failed")
 				maintenance := &v1beta1.NodeMaintenance{}
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.DrainProgress).To(BeNumerically(">", 0))
 					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(BeNumerically(">", maxAllowedErrorToUpdateOwnedLease))
 					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
-				}, "10s", "500ms").Should(Succeed())
+				}, defaultTimeout, defaultInterval).Should(Succeed())
 
 				By("Verifying maintenance failed event was emitted")
 				verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
@@ -563,8 +575,7 @@ func clearEvents() {
 
 type mockLeaseManager struct {
 	lease.Manager
-	requestLeaseErr    error
-	invalidateLeaseErr error
+	requestLeaseErr error
 
 	// failAfterSuccesses: if > 0, the first N RequestLease calls succeed,
 	// then requestLeaseErr is returned. Use for "succeed then fail" scenarios.
@@ -591,11 +602,4 @@ func (mock *mockLeaseManager) RequestLease(_ context.Context, _ client.Object, _
 	}
 	mock.failCount++
 	return mock.requestLeaseErr
-}
-
-func (mock *mockLeaseManager) InvalidateLease(ctx context.Context, obj client.Object) error {
-	if mock.invalidateLeaseErr != nil {
-		return mock.invalidateLeaseErr
-	}
-	return mock.Manager.InvalidateLease(ctx, obj)
 }

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -276,20 +276,21 @@ var _ = Describe("Node Maintenance", func() {
 				Expect(k8sClient.Create(ctx, nm)).To(Succeed())
 				DeferCleanup(k8sClient.Delete, ctx, nm)
 			})
-			It("should increment ErrorOnLeaseCount and fail maintenance after exceeding max retries", func() {
-				By("Waiting for ErrorOnLeaseCount to exceed the threshold and phase to become Failed")
+			It("should retry without incrementing ErrorOnLeaseCount when DrainProgress is 0", func() {
+				By("Waiting for the reconciler to attempt lease acquisition and report the error")
 				maintenance := &v1beta1.NodeMaintenance{}
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
-					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(BeNumerically(">", maxAllowedErrorToUpdateOwnedLease))
-					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
+					g.Expect(maintenance.Status.LastError).To(ContainSubstring("failed to obtain a lease that is not owned by us"))
 				}, "2s", "500ms").Should(Succeed())
 
-				By("Verifying maintenance failed event was emitted")
-				verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+				By("Verifying ErrorOnLeaseCount stays at 0 since DrainProgress is 0")
+				Expect(maintenance.Status.ErrorOnLeaseCount).To(Equal(0))
+				Expect(maintenance.Status.DrainProgress).To(Equal(0))
 
-				By("Verifying LastError mentions lease contention")
-				Expect(maintenance.Status.LastError).To(ContainSubstring("failed to extend lease owned by us"))
+				By("Verifying maintenance stays in Running phase, not Failed")
+				Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceRunning))
+				verifyNoEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
 			})
 		})
 		When("lease is held then released by another entity", func() {
@@ -297,8 +298,8 @@ var _ = Describe("Node Maintenance", func() {
 				originalLeaseManager := r.LeaseManager
 				// The mock returns AlreadyHeldError for exactly (maxAllowedErrorToUpdateOwnedLease + 2)
 				// RequestLease calls, then returns nil — simulating NHC releasing the lease.
-				// This limits rate limiter failures so the recovery reconcile happens quickly
-				// (backoff stays under 1s), avoiding the 40s+ backoff from unlimited failures.
+				// Since DrainProgress=0 throughout the failure period, ErrorOnLeaseCount is never
+				// incremented and no FailedMaintenance event is emitted.
 				r.LeaseManager = &mockLeaseManager{
 					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
 					requestLeaseErr:    lease.AlreadyHeldError{},
@@ -313,13 +314,8 @@ var _ = Describe("Node Maintenance", func() {
 				Expect(k8sClient.Create(ctx, nm)).To(Succeed())
 				DeferCleanup(k8sClient.Delete, ctx, nm)
 			})
-			It("should wait for lease to be released and succeed maintenance after lease is released", func() {
-				By("Waiting for NMO to fail from lease contention, then recover after lease is released")
-				Eventually(func() error {
-					verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
-					return nil
-				}, "5s", "200ms").Should(Succeed())
-
+			It("should succeed maintenance directly after lease is released without entering Failed state", func() {
+				By("Waiting for NMO to acquire the lease and complete maintenance")
 				maintenance := &v1beta1.NodeMaintenance{}
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
@@ -335,7 +331,83 @@ var _ = Describe("Node Maintenance", func() {
 				Expect(isTaintExist(node, medik8sDrainTaint.Key, corev1.TaintEffectNoSchedule)).To(BeTrue())
 				Expect(isTaintExist(node, nodeUnschedulableTaint.Key, corev1.TaintEffectNoSchedule)).To(BeTrue())
 
+				verifyNoEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
 				verifyEvent(corev1.EventTypeNormal, utils.EventReasonSucceedMaintenance, utils.EventMessageSucceedMaintenance)
+			})
+		})
+		When("lease is transiently lost during maintenance", func() {
+			BeforeEach(func() {
+				originalLeaseManager := r.LeaseManager
+				// First RequestLease succeeds (NMO starts maintenance), then 2 calls
+				// fail with AlreadyHeldError (another entity temporarily takes the
+				// lease), then succeed again (lease released back to NMO).
+				// 2 failures < threshold of 4, so NMO suspends, then resumes
+				// maintenance and eventually succeeds.
+				r.LeaseManager = &mockLeaseManager{
+					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
+					requestLeaseErr:    lease.AlreadyHeldError{},
+					invalidateLeaseErr: lease.AlreadyHeldError{},
+					failAfterSuccesses: 1,
+					maxRequestFailures: 2,
+				}
+				DeferCleanup(func() {
+					r.LeaseManager = originalLeaseManager
+				})
+
+				nm = getTestNM("node-maintenance-lease-recovered", taintedNodeName)
+				Expect(k8sClient.Create(ctx, nm)).To(Succeed())
+				DeferCleanup(k8sClient.Delete, ctx, nm)
+			})
+			It("should suspend, recover the lease, and succeed maintenance", func() {
+				By("Waiting for NMO to recover the lease and complete maintenance")
+				maintenance := &v1beta1.NodeMaintenance{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceSucceeded))
+					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(Equal(0))
+					g.Expect(maintenance.Status.DrainProgress).To(Equal(100))
+				}, "10s", "500ms").Should(Succeed())
+
+				By("Verifying no FailedMaintenance event was emitted")
+				verifyNoEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+				verifyEvent(corev1.EventTypeNormal, utils.EventReasonSucceedMaintenance, utils.EventMessageSucceedMaintenance)
+			})
+		})
+		When("lease is permanently lost during maintenance", func() {
+			BeforeEach(func() {
+				originalLeaseManager := r.LeaseManager
+				// First RequestLease succeeds (NMO starts maintenance), then all
+				// subsequent calls return AlreadyHeldError — simulating the lease
+				// being permanently taken by another entity during maintenance.
+				// ErrorOnLeaseCount exceeds the threshold and NMO gives up.
+				r.LeaseManager = &mockLeaseManager{
+					Manager:            originalLeaseManager.(*mockLeaseManager).Manager,
+					requestLeaseErr:    lease.AlreadyHeldError{},
+					invalidateLeaseErr: lease.AlreadyHeldError{},
+					failAfterSuccesses: 1,
+				}
+				DeferCleanup(func() {
+					r.LeaseManager = originalLeaseManager
+				})
+
+				nm = getTestNM("node-maintenance-lease-lost", taintedNodeName)
+				Expect(k8sClient.Create(ctx, nm)).To(Succeed())
+				DeferCleanup(k8sClient.Delete, ctx, nm)
+			})
+			It("should fail maintenance when lease cannot be recovered", func() {
+				By("Waiting for ErrorOnLeaseCount to exceed the threshold and phase to become Failed")
+				maintenance := &v1beta1.NodeMaintenance{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.ErrorOnLeaseCount).To(BeNumerically(">", maxAllowedErrorToUpdateOwnedLease))
+					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceFailed))
+				}, "10s", "500ms").Should(Succeed())
+
+				By("Verifying maintenance failed event was emitted")
+				verifyEvent(corev1.EventTypeWarning, utils.EventReasonFailedMaintenance, utils.EventMessageFailedMaintenance)
+
+				By("Verifying LastError mentions lease extension failure")
+				Expect(maintenance.Status.LastError).To(ContainSubstring("maintenance failed: lease could not be extended"))
 			})
 		})
 	})
@@ -491,24 +563,34 @@ func clearEvents() {
 
 type mockLeaseManager struct {
 	lease.Manager
-	requestLeaseErr error
-	// maxRequestFailures limits how many times RequestLease returns requestLeaseErr.
-	// 0 means unlimited (fail forever). When requestFailCount reaches maxRequestFailures,
-	// RequestLease returns nil — simulating the lease being released.
-	maxRequestFailures int
-	requestFailCount   int
-
+	requestLeaseErr    error
 	invalidateLeaseErr error
+
+	// failAfterSuccesses: if > 0, the first N RequestLease calls succeed,
+	// then requestLeaseErr is returned. Use for "succeed then fail" scenarios.
+	failAfterSuccesses int
+	// maxRequestFailures: if > 0, requestLeaseErr is returned for at most N calls,
+	// then nil is returned. 0 means unlimited failures once they start.
+	// Use for "fail then succeed" scenarios.
+	maxRequestFailures int
+
+	callCount int
+	failCount int
 }
 
 func (mock *mockLeaseManager) RequestLease(_ context.Context, _ client.Object, _ time.Duration) error {
-	if mock.requestLeaseErr != nil {
-		if mock.maxRequestFailures <= 0 || mock.requestFailCount < mock.maxRequestFailures {
-			mock.requestFailCount++
-			return mock.requestLeaseErr
-		}
+	if mock.requestLeaseErr == nil {
+		return nil
 	}
-	return nil
+	mock.callCount++
+	if mock.failAfterSuccesses > 0 && mock.callCount <= mock.failAfterSuccesses {
+		return nil
+	}
+	if mock.maxRequestFailures > 0 && mock.failCount >= mock.maxRequestFailures {
+		return nil
+	}
+	mock.failCount++
+	return mock.requestLeaseErr
 }
 
 func (mock *mockLeaseManager) InvalidateLease(ctx context.Context, obj client.Object) error {


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
ErrorOnLeaseCount of NM CR status was never incremented when obtainLease never returned a 'true' value. Resulting in NMO keeps trying to get a lease and not stopping until a change in the node happens

#### Changes made
<!-- Outline the specific changes made in this merge request. -->

- Simplify obtainLease function
- Add logic to distinguish an `AlreadyHeldError` 
   - so that ErrorOnLeaseCount can be incremented and NMO would uncordon the node and reach to Failed maintenance phase.
   - so we skip the lease invalidation logic after `InvalidateLease` function on NM CR cleanup

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->

[RHWA-744](https://issues.redhat.com/browse/RHWA-744)
#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
- New unit test when the lease is already held by another entity
- New unit test when the lease is already held by another entity, released, and then NMO takes the lease

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lease contention handling: already-held leases are treated as expected contention, error counters and cleanup now behave more reliably, preventing spurious failures and ensuring correct maintenance phase transitions.
* **Tests**
  * Added scenarios for lease contention and subsequent recovery, validating error counting, maintenance failure/success transitions, emitted events, and node cordon/taint and drain progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->