### PR TITLE
Modernize release workflow: replace deprecated action, bump checkout, rename reusable workflow

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -15,7 +15,7 @@ jobs: # jobs to run
     runs-on: ubuntu-22.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs: # jobs to run
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,11 +59,13 @@ jobs:
       - name: Build and push versioned CSV and images
         run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION make container-build-community container-push
 
-      - name: Create release with manifests, for tags
-        # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
-        uses: meeDamian/github-release@2.0
+      - name: Compress bundle manifests
+        run: tar czf bundle.tar.gz bundle/
+
+      - name: Create release with manifests
+        uses: softprops/action-gh-release@v2
         with:
-          tag: v${{ inputs.version }}
+          tag_name: v${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
           body: |
@@ -82,9 +84,7 @@ jobs:
 
             ### Source code and OLM manifests
             Please find the source code and the OLM manifests in the `Assets` section below.
-          gzip: folders
-          files: >
-            Manifests:bundle/
+          files: bundle.tar.gz
 
   create_k8s_release_pr:
     if: inputs.operation == 'create_k8s_release_pr'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
 
   create_k8s_release_pr:
     if: inputs.operation == 'create_k8s_release_pr'
-    uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
+    uses: medik8s/.github/.github/workflows/release_community_bundle.yaml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}
@@ -97,7 +97,7 @@ jobs:
       make_targets: "bundle-community-k8s"
   create_okd_release_pr:
     if: inputs.operation == 'create_okd_release_pr'
-    uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
+    uses: medik8s/.github/.github/workflows/release_community_bundle.yaml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           echo "which replaces version: ${PREVIOUS_VERSION}."
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
#### Why we need this PR

1. The `meeDamian/github-release@2.0` action used in the release workflow relies on the deprecated `set-output` command, which GitHub has disabled. The `meeDamian/github-release` action is no longer maintained and will eventually stop working.

2. `actions/checkout` has a new major version available (v4 → v6).

3. The shared reusable workflow `release_community_bundle_parametric.yaml` was renamed to `release_community_bundle.yaml` in `medik8s/.github` for clarity (the old `release_rh_community_bundle.yaml` was removed since all operators use the parametric workflow).

#### Changes made

- Replaced `meeDamian/github-release@2.0` with the actively maintained `softprops/action-gh-release@v2`, which uses the modern `$GITHUB_OUTPUT` environment files
- Added an explicit step to compress the `bundle/` directory into `bundle.tar.gz`, since `softprops/action-gh-release` does not have a built-in `gzip: folders` option
- Bumped `actions/checkout` from v4 to v6 in all workflows (release, pre-submit, post-submit)
- Updated reusable workflow references from `release_community_bundle_parametric.yaml` to `release_community_bundle.yaml`

#### Which issue(s) this PR fixes

- Fixes the `set-output` deprecation warning in the `build_and_push_images` release workflow.
- Aligns with the reusable workflow rename in medik8s/.github.

#### Test plan

- [ ] Trigger the `build_and_push_images` operation in the Release workflow and verify the deprecation warning is gone
- [ ] Verify the draft GitHub release is created correctly with the `bundle.tar.gz` asset attached
- [ ] Verify pre-submit and post-submit workflows still pass with checkout v6
- [ ] Verify `create_k8s_release_pr` and `create_okd_release_pr` operations work with the renamed reusable workflow (requires merging the rename in medik8s/.github first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use the latest versions of external actions and improved release process efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->