### PR TITLE
Add optional checkout_ref input to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,10 @@ on:
      ocp_version:
        description: "The target OCP version for the release (mandatory for create_okd_release_pr option)"
        required: false
+     checkout_ref:
+       description: 'Override the ref to checkout (defaults to the triggering ref)'
+       required: false
+       default: ''
 
 permissions:
   contents: write
@@ -42,6 +46,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
           fetch-depth: 0
 
       - name: Set up Go


### PR DESCRIPTION
## Summary

- Add an optional `checkout_ref` input to the release workflow, allowing the user to override the git ref checked out during the release process
- Defaults to the triggering ref (`github.ref`) when not specified
- Useful when a release needs to be built from a specific tag or branch that differs from the workflow trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>