### PR TITLE
Fix deletion handling: prevent re-cordon when finalizer is already removed

### DIFF
--- a/controllers/nodemaintenance_controller.go
+++ b/controllers/nodemaintenance_controller.go
@@ -127,7 +127,31 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return emptyResult, err
 	}
 
-	if !controllerutil.ContainsFinalizer(nm, v1beta1.NodeMaintenanceFinalizer) && nm.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !nm.ObjectMeta.DeletionTimestamp.IsZero() {
+		// The object is being deleted
+		r.logger.Info("Deletion timestamp not zero")
+
+		if controllerutil.ContainsFinalizer(nm, v1beta1.NodeMaintenanceFinalizer) {
+			// Stop node maintenance - uncordon and remove live migration taint from the node.
+			if err := r.stopNodeMaintenanceOnDeletion(ctx, drainer, nm.Spec.NodeName); err != nil {
+				r.logger.Error(err, "error stopping node maintenance")
+				if !apiErrors.IsNotFound(err) {
+					return r.onReconcileError(ctx, nm, drainer, err)
+				}
+			}
+
+			// Remove finalizer
+			controllerutil.RemoveFinalizer(nm, v1beta1.NodeMaintenanceFinalizer)
+			if err := r.Client.Update(ctx, nm); err != nil {
+				return r.onReconcileError(ctx, nm, drainer, err)
+			}
+			// end maintenance on removing finalizer, taints, and node is already uncordoned
+			utils.NormalEvent(r.Recorder, nm, utils.EventReasonRemovedMaintenance, utils.EventMessageRemovedMaintenance)
+		}
+		return emptyResult, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(nm, v1beta1.NodeMaintenanceFinalizer) {
 		// Add finalizer when object is created
 		controllerutil.AddFinalizer(nm, v1beta1.NodeMaintenanceFinalizer)
 		if err := r.Client.Update(ctx, nm); err != nil {
@@ -135,26 +159,6 @@ func (r *NodeMaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		// begin maintenance on adding finalizer
 		utils.NormalEvent(r.Recorder, nm, utils.EventReasonBeginMaintenance, utils.EventMessageBeginMaintenance)
-	} else if controllerutil.ContainsFinalizer(nm, v1beta1.NodeMaintenanceFinalizer) && !nm.ObjectMeta.DeletionTimestamp.IsZero() {
-		// The object is being deleted
-		r.logger.Info("Deletion timestamp not zero")
-
-		// Stop node maintenance - uncordon and remove live migration taint from the node.
-		if err := r.stopNodeMaintenanceOnDeletion(ctx, drainer, nm.Spec.NodeName); err != nil {
-			r.logger.Error(err, "error stopping node maintenance")
-			if !apiErrors.IsNotFound(err) {
-				return r.onReconcileError(ctx, nm, drainer, err)
-			}
-		}
-
-		// Remove finalizer
-		controllerutil.RemoveFinalizer(nm, v1beta1.NodeMaintenanceFinalizer)
-		if err := r.Client.Update(ctx, nm); err != nil {
-			return r.onReconcileError(ctx, nm, drainer, err)
-		}
-		// end maintenance on removing finalizer, taints, and node is already uncordoned
-		utils.NormalEvent(r.Recorder, nm, utils.EventReasonRemovedMaintenance, utils.EventMessageRemovedMaintenance)
-		return emptyResult, nil
 	}
 
 	needUpdate, err := initMaintenanceStatus(ctx, nm, drainer)

--- a/controllers/nodemaintenance_controller_test.go
+++ b/controllers/nodemaintenance_controller_test.go
@@ -385,6 +385,55 @@ var _ = Describe("Node Maintenance", func() {
 				verifyEvent(corev1.EventTypeNormal, utils.EventReasonSucceedMaintenance, utils.EventMessageSucceedMaintenance)
 			})
 		})
+		When("nm CR is deleted and NMO finalizer is already removed", func() {
+			BeforeEach(func() {
+				nm = getTestNM("node-maintenance-cr-deletion-no-finalizer", taintedNodeName)
+				// Add a blocker finalizer to keep the NM alive after NMO removes its own
+				// finalizer during deletion. This forces repeated reconciles in the
+				// "deleting + no NMO finalizer" state — the exact edge case where the old
+				// code would fall through to normal reconcile and re-cordon the node.
+				nm.Finalizers = []string{"test/blocker"}
+				Expect(k8sClient.Create(ctx, nm)).To(Succeed())
+				DeferCleanup(func() {
+					maintenance := &v1beta1.NodeMaintenance{}
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance); err != nil {
+						return
+					}
+					maintenance.Finalizers = nil
+					_ = k8sClient.Update(ctx, maintenance)
+				})
+			})
+			It("should not re-apply maintenance to the node", func() {
+				By("Waiting for maintenance to succeed")
+				maintenance := &v1beta1.NodeMaintenance{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+					g.Expect(maintenance.Status.Phase).To(Equal(v1beta1.MaintenanceSucceeded))
+				}, defaultTimeout, defaultInterval).Should(Succeed())
+
+				By("Deleting the nm CR — NMO will uncordon and remove its finalizer, but test/blocker keeps the object alive")
+				Expect(k8sClient.Delete(ctx, nm)).To(Succeed())
+
+				By("Waiting for NMO to process deletion and uncordon the node")
+				Eventually(func(g Gomega) {
+					node := &corev1.Node{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, node)).To(Succeed())
+					g.Expect(node.Spec.Unschedulable).To(BeFalse())
+				}, defaultTimeout, defaultInterval).Should(Succeed())
+
+				By("Verifying NMO finalizer was removed but NM still exists due to blocker")
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nm), maintenance)).To(Succeed())
+				Expect(maintenance.Finalizers).To(Equal([]string{"test/blocker"}))
+
+				By("Verifying node stays uncordoned — no rogue reconcile re-applies maintenance")
+				Consistently(func(g Gomega) {
+					node := &corev1.Node{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: taintedNodeName}, node)).To(Succeed())
+					g.Expect(node.Spec.Unschedulable).To(BeFalse())
+					g.Expect(isTaintExist(node, medik8sDrainTaint.Key, corev1.TaintEffectNoSchedule)).To(BeFalse())
+				}, 2*time.Second, defaultInterval).Should(Succeed())
+			})
+		})
 		When("lease is permanently lost during maintenance", func() {
 			BeforeEach(func() {
 				originalLeaseManager := r.LeaseManager


### PR DESCRIPTION
#### Why we need this PR

Fixes a race condition where deleting a NodeMaintenance CR on an existing node sometimes leaves taints/cordon in place. When the NMO finalizer is removed during deletion cleanup, the resulting update triggers another reconcile. In the old code, this reconcile sees `!hasFinalizer && deleting` — which matches neither branch of the `if/else-if` chain — and falls through to the normal maintenance path, re-cordoning and re-tainting the node.

This is an alternative implementation of #154, restructured as suggested by @clobrano in the [review comments](https://github.com/medik8s/node-maintenance-operator/pull/154#issuecomment-3370410053).

#### Changes made

- Restructured the reconcile loop to check `DeletionTimestamp` first as the primary decision driver
- If deleting: run cleanup (if finalizer present), then always return early — never fall through to normal reconcile
- If not deleting and no finalizer: add the finalizer  
- Otherwise: proceed with normal reconcile
- Added a unit test that deterministically reproduces the edge case using a blocker finalizer to keep the NM object alive in the `deleting + no NMO finalizer` state, and `Consistently` to verify the node is not re-cordoned

#### Which issue(s) this PR fixes

Supersedes #154

#### Test plan

- Existing unit tests pass (12/12 controller specs)
- New test `"nm CR is deleted and NMO finalizer is already removed"` deterministically reproduces the race condition:
  1. A blocker finalizer keeps the NM alive after NMO removes its own finalizer during deletion
  2. The controller keeps reconciling the object in the `deleting + no NMO finalizer` state
  3. `Consistently` verifies the node stays uncordoned over 2 seconds
  4. With the old code this test would fail because each rogue reconcile re-cordons the node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node maintenance deletion flow to ensure nodes are correctly uncordoned when maintenance is removed.
  * Enhanced handling of edge cases during maintenance removal to prevent unexpected behavior.

* **Tests**
  * Added test coverage for node maintenance deletion scenarios to verify proper node uncordoning and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->