### PR TITLE
Modernize GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -24,7 +24,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   push_to_registry:
     name: Build and push unversioned images to quay.io/medik8s
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -12,7 +12,7 @@ on: # on events
 jobs: # jobs to run
   build:
     name: Test and build PRs
-    runs-on: ubuntu-22.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+    runs-on: ubuntu-24.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -32,7 +32,7 @@ jobs: # jobs to run
 
   scorecard-k8s:
     name: Test Scorecard Tests # https://sdk.operatorframework.io/docs/testing-operators/scorecard/
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # see https://github.com/kubernetes-sigs/kind/tags
       KIND_VERSION: v0.22.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
   push_to_registry:
     if: ${{ inputs.operation == 'build_and_push_images' }}
     name: Build and push versioned images to quay.io/medik8s
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       VERSION: ${{ inputs.version }}
       PREVIOUS_VERSION: ${{ inputs.previous_version }}


### PR DESCRIPTION
#### Why we need this PR
Modernize GitHub Actions to current stable versions.

#### Changes made
- Bump `docker/login-action` from v3 to v4
- Update runner image from ubuntu-22.04 to ubuntu-24.04

#### Which issue(s) this PR fixes
Contributes to [RHWA-852](https://redhat.atlassian.net/browse/RHWA-852) and [RHWA-853](https://redhat.atlassian.net/browse/RHWA-853)

#### Test plan
- CI pre-submit passes with updated action versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner environment to Ubuntu 24.04 across build and release workflows
  * Updated container registry authentication action to the latest version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->