### PR TITLE
Add NetworkPolicy RBAC permission

### DIFF
--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -162,6 +162,14 @@ spec:
           - create
           - get
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - nodemaintenance.medik8s.io
           resources:
           - nodemaintenances

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,14 @@ rules:
   - create
   - get
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - nodemaintenance.medik8s.io
   resources:
   - nodemaintenances

--- a/internal/controller/nodemaintenance_controller.go
+++ b/internal/controller/nodemaintenance_controller.go
@@ -91,6 +91,7 @@ func (r *NodeMaintenanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=get;create
 //+kubebuilder:rbac:groups="oauth.openshift.io",resources=*,verbs=*
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## Summary

Add `networking.k8s.io/networkpolicies` RBAC (create, delete, update) to allow managing NetworkPolicies for operand workloads.

## Changes

- Add kubebuilder RBAC marker to controller
- Regenerate `config/rbac/role.yaml`
- Regenerate bundle CSV

## Test plan

- [x] `make manifests` — RBAC generated correctly
- [x] `make bundle` — bundle validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)