### PR TITLE
Update to 5.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ IMAGE_REGISTRY ?= quay.io/medik8s
 export IMAGE_REGISTRY
 
 # When no version is set, use latest as image tags
-DEFAULT_VERSION := 0.0.1
+DEFAULT_VERSION := 5.8.0
 ifeq ($(origin VERSION), undefined)
 IMAGE_TAG = latest
 else ifeq ($(VERSION), $(DEFAULT_VERSION))

--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: node-maintenance-operator
-repo: github.com/medik8s/node-maintenance-operator
+repo: github.com/medik8s/node-maintenance-operator/v5
 resources:
 - api:
     crdVersion: v1
@@ -14,7 +14,7 @@ resources:
   domain: medik8s.io
   group: nodemaintenance
   kind: NodeMaintenance
-  path: github.com/medik8s/node-maintenance-operator
+  path: github.com/medik8s/node-maintenance-operator/v5
   version: v1beta1
   webhooks:
     validation: true

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -21,14 +21,14 @@ metadata:
     containerImage: ""
     createdAt: ""
     description: Node Maintenance Operator for cordoning and draining nodes.
-    olm.skipRange: '>=0.12.0'
+    olm.skipRange: '>=0.12.0 <5.8.0'
     operatorframework.io/suggested-namespace: openshift-workload-availability
     operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/medik8s/node-maintenance-operator
     support: Medik8s
-  name: node-maintenance-operator.v0.0.1
+  name: node-maintenance-operator.v5.8.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -265,7 +265,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/medik8s/node-maintenance-operator:latest
+                image: quay.io/medik8s/node-maintenance-operator:v5.8.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -378,7 +378,8 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
-  version: 0.0.1
+  version: 5.8.0
+  replaces: node-maintenance-operator.v0.21.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/medik8s/node-maintenance-operator
     support: Medik8s
-  name: node-maintenance-operator.v0.0.1
+  name: node-maintenance-operator.v5.8.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -378,7 +378,7 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
-  version: 0.0.1
+  version: 5.8.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -21,14 +21,14 @@ metadata:
     containerImage: ""
     createdAt: ""
     description: Node Maintenance Operator for cordoning and draining nodes.
-    olm.skipRange: '>=0.12.0 <5.8.0'
+    olm.skipRange: '>=0.12.0'
     operatorframework.io/suggested-namespace: openshift-workload-availability
     operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/medik8s/node-maintenance-operator
     support: Medik8s
-  name: node-maintenance-operator.v5.8.0
+  name: node-maintenance-operator.v0.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -265,7 +265,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/medik8s/node-maintenance-operator:v5.8.0
+                image: quay.io/medik8s/node-maintenance-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -378,8 +378,7 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
-  version: 5.8.0
-  replaces: node-maintenance-operator.v0.21.0
+  version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,11 +49,11 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
 
-	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/api/v1beta1"
-	"github.com/medik8s/node-maintenance-operator/internal/controller"
-	webhookv1beta1 "github.com/medik8s/node-maintenance-operator/internal/webhook/v1beta1"
-	"github.com/medik8s/node-maintenance-operator/pkg/utils"
-	"github.com/medik8s/node-maintenance-operator/version"
+	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
+	"github.com/medik8s/node-maintenance-operator/v5/internal/controller"
+	webhookv1beta1 "github.com/medik8s/node-maintenance-operator/v5/internal/webhook/v1beta1"
+	"github.com/medik8s/node-maintenance-operator/v5/pkg/utils"
+	"github.com/medik8s/node-maintenance-operator/v5/version"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/medik8s/node-maintenance-operator
+module github.com/medik8s/node-maintenance-operator/v5
 
 // min version, matches k8s 1.34.7
 go 1.26.0

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -8,9 +8,9 @@ BUILD_DATE=$(date --utc -Iseconds)
 
 mkdir -p bin
 
-LDFLAGS_VALUE="-X github.com/medik8s/node-maintenance-operator/version.Version=${VERSION} "
-LDFLAGS_VALUE+="-X github.com/medik8s/node-maintenance-operator/version.GitCommit=${COMMIT} "
-LDFLAGS_VALUE+="-X github.com/medik8s/node-maintenance-operator/version.BuildDate=${BUILD_DATE} "
+LDFLAGS_VALUE="-X github.com/medik8s/node-maintenance-operator/v5/version.Version=${VERSION} "
+LDFLAGS_VALUE+="-X github.com/medik8s/node-maintenance-operator/v5/version.GitCommit=${COMMIT} "
+LDFLAGS_VALUE+="-X github.com/medik8s/node-maintenance-operator/v5/version.BuildDate=${BUILD_DATE} "
 # allow override for debugging flags
 LDFLAGS_DEBUG="${LDFLAGS_DEBUG:-" -s -w"}"
 LDFLAGS_VALUE+="${LDFLAGS_DEBUG}"

--- a/internal/controller/controllers_suite_test.go
+++ b/internal/controller/controllers_suite_test.go
@@ -35,7 +35,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/api/v1beta1"
+	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/nodemaintenance_controller.go
+++ b/internal/controller/nodemaintenance_controller.go
@@ -43,8 +43,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/medik8s/node-maintenance-operator/api/v1beta1"
-	"github.com/medik8s/node-maintenance-operator/pkg/utils"
+	"github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
+	"github.com/medik8s/node-maintenance-operator/v5/pkg/utils"
 )
 
 const (

--- a/internal/controller/nodemaintenance_controller_test.go
+++ b/internal/controller/nodemaintenance_controller_test.go
@@ -18,8 +18,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/medik8s/node-maintenance-operator/api/v1beta1"
-	utils "github.com/medik8s/node-maintenance-operator/pkg/utils"
+	"github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
+	utils "github.com/medik8s/node-maintenance-operator/v5/pkg/utils"
 )
 
 const (

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -3,7 +3,7 @@ package controller
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/medik8s/node-maintenance-operator/api/v1beta1"
+	"github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
 )
 
 // ContainsString checks if the string array contains the given string.

--- a/internal/webhook/v1beta1/nodemaintenance_webhook.go
+++ b/internal/webhook/v1beta1/nodemaintenance_webhook.go
@@ -31,7 +31,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/api/v1beta1"
+	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
 )
 
 const (

--- a/internal/webhook/v1beta1/nodemaintenance_webhook_test.go
+++ b/internal/webhook/v1beta1/nodemaintenance_webhook_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/api/v1beta1"
+	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
 )
 
 var _ = Describe("NodeMaintenance Validation", func() {

--- a/internal/webhook/v1beta1/webhook_suite_test.go
+++ b/internal/webhook/v1beta1/webhook_suite_test.go
@@ -43,7 +43,7 @@ import (
 	metricsServer "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/api/v1beta1"
+	nodemaintenancev1beta1 "github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/test/e2e/clients.go
+++ b/test/e2e/clients.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	//operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	nmoapi "github.com/medik8s/node-maintenance-operator/api/v1beta1"
+	nmoapi "github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
 )
 
 var (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/medik8s/node-maintenance-operator/api/v1beta1"
+	"github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
 )
 
 const (

--- a/test/e2e/node_maintenance_test.go
+++ b/test/e2e/node_maintenance_test.go
@@ -23,9 +23,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	nmo "github.com/medik8s/node-maintenance-operator/api/v1beta1"
-	nodemaintenance "github.com/medik8s/node-maintenance-operator/internal/controller"
-	"github.com/medik8s/node-maintenance-operator/pkg/utils"
+	nmo "github.com/medik8s/node-maintenance-operator/v5/api/v1beta1"
+	nodemaintenance "github.com/medik8s/node-maintenance-operator/v5/internal/controller"
+	"github.com/medik8s/node-maintenance-operator/v5/pkg/utils"
 )
 
 const (

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// Version is the operator version
-	Version = "0.0.1"
+	Version = "5.8.0"
 	// GitCommit is the current git commit hash
 	GitCommit = "n/a"
 	// BuildDate is the build date


### PR DESCRIPTION
Renames the Go module to `/v5` per Go's semantic import versioning rules (required for a v5.x tag), rewrites all internal imports accordingly, and bumps the CSV to 5.8.0.

Follows the pattern established in [node-healthcheck-operator#430](https://github.com/medik8s/node-healthcheck-operator/pull/430).

Draft while the version number (5.8.0) and this pattern get confirmed with the team.

Addresses https://redhat.atlassian.net/browse/RHWA-1395 
---

Manually verified the real OLM upgrade path end-to-end on a live OCP test cluster: built the actual v5.8.0 operator/bundle/catalog images, pushed them to a test registry, stood up a real `CatalogSource`, and switched the existing GA subscription to it. OLM resolved the `replaces`/`skipRange` edge from the currently-shipped GA CSV (v5.7.1) and completed a real upgrade — old CSV transitioned through `Replacing`, new CSV reached `Succeeded`, and the controller pod came up `Running` on the new image.